### PR TITLE
feature: icons only badges

### DIFF
--- a/src/lib/badges/Badge.svelte
+++ b/src/lib/badges/Badge.svelte
@@ -5,6 +5,7 @@
 	export let color: Colors = 'blue';
 	export let large: boolean = false;
 	export let href: string;
+	export let rounded: boolean = false;
 
 	let badgeClass;
 
@@ -31,14 +32,15 @@
 	};
 
 	$: badgeClass = classNames(
-		'inline-flex items-center mr-2 px-2.5 py-0.5 rounded',
+		'inline-flex items-center justify-center mr-2',
 		large ? 'text-sm font-medium' : 'text-xs font-semibold',
 		colors[color] ?? colors.blue,
 		href && (hovers[color] ?? hovers.blue),
+		rounded ? 'rounded-full p-1' : 'rounded px-2.5 py-0.5',
 		$$props.class
 	);
 </script>
 
-<svelte:element this={href ? 'a' : 'span'} {href} class={badgeClass} {...$$restProps}>
+<svelte:element this={href ? 'a' : 'span'} {href} {...$$restProps} class={badgeClass}>
 	<slot />
 </svelte:element>

--- a/src/routes/badges/index.md
+++ b/src/routes/badges/index.md
@@ -8,7 +8,7 @@ layout: badgeLayout
   import TableProp from '../utils/TableProp.svelte'
   import TableDefaultRow from '../utils/TableDefaultRow.svelte'
   import { Badge, Card, Breadcrumb, BreadcrumbItem } from '$lib/index'
-  import { Home, Clock } from 'svelte-heros';
+  import { Home, Clock, Check } from 'svelte-heros';
   import componentProps from '../props/Badge.json'
   // Props table
   let items = componentProps.props
@@ -28,6 +28,7 @@ layout: badgeLayout
 ```html
 <script>
   import { Badge } from 'flowbite-svelte'
+  import { Clock, Check } from 'svelte-heros'
 </script>
 ```
 
@@ -105,15 +106,27 @@ layout: badgeLayout
 <Badge large={true}><Clock class="mr-1 w-4 h-4"/>2 minutes ago</Badge>
 </ExampleDiv>
 
-
-
 ```html
-<script>
-  import { Clock } from 'svelte-heros'
-</script>
-
 <Badge color="dark"><Clock class="mr-1 w-3 h-3"/>3 days ago</Badge>
 <Badge large={true}><Clock class="mr-1 w-4 h-4"/>2 minutes ago</Badge>
+```
+
+<Htwo label="Badge with icon only" />
+
+<p>Alternatively you can also use badges which indicate only a SVG icon.</p>
+
+<ExampleDiv class="justify-start gap-2">
+<Badge rounded ><Check class="w-3 h-3"/></Badge>
+<Badge rounded color="dark" ><Check class="w-3 h-3"/></Badge>
+<Badge rounded large ><Check class="w-4 h-4"/></Badge>
+<Badge rounded large color="dark" ><Check class="w-4 h-4"/></Badge>
+</ExampleDiv>
+
+```html
+<Badge rounded ><Check class="w-3 h-3"/></Badge>
+<Badge rounded color="dark" ><Check class="w-3 h-3"/></Badge>
+<Badge rounded large ><Check class="w-4 h-4"/></Badge>
+<Badge rounded large color="dark" ><Check class="w-4 h-4"/></Badge>
 ```
 
 <Htwo label="Props" />

--- a/src/routes/props/Badge.json
+++ b/src/routes/props/Badge.json
@@ -1,1 +1,1 @@
-{"props":[["color","Colors ","'blue'"],["large","boolean ","false"],[" href"," string",""]]}
+{"props":[["color","Colors ","'blue'"],["large","boolean ","false"],[" href"," string",""],["rounded","boolean ","false"]]}


### PR DESCRIPTION
## 📑 Description

Added property rounded that set 'rounded-full' class to the badge to support icon only use-case.
Minor fixes:
- setting class on badge is possible now
- justify-center added for content alignment

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit/version

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
