### PR TITLE
fix: toc more selective

### DIFF
--- a/src/routes/Toc.svelte
+++ b/src/routes/Toc.svelte
@@ -3,39 +3,36 @@
         Simplified version of Table of Contents.
     */
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
 
-	export let headingSelector = `main :where(h2, h3, h4):not(.toc-exclude)`;
+	export let headingSelector = `main :where(h2.htwo):not(.toc-exclude,#References,#Related_components)`;
 	let headings = [];
 
-	function requery_headings() {
-		if (typeof document === `undefined`) return; // for SSR safety
-		headings = [...document.querySelectorAll(headingSelector)].map((x) => {
+	$: $page &&
+		typeof document !== `undefined` &&
+		(headings = [...document.querySelectorAll(headingSelector)].map((x) => {
 			return { href: '#' + x.id, label: x.innerText };
-		});
-	}
-
-	page.subscribe(requery_headings);
-	onMount(requery_headings);
+		}));
 </script>
 
-<div class="hidden flex-none pl-8 mr-8 w-64 xl:text-sm xl:block text-gray-500 dark:text-gray-400">
-	<div
-		class="flex flex-col justify-between overflow-y-auto sticky max-h-(screen-18) pt-10 pb-6 top-12"
-	>
-		<div class="mb-8">
-			<h5
-				class="mb-3 text-sm font-semibold tracking-wide text-gray-900 uppercase dark:text-white lg:text-xs"
-			>
-				On this page
-			</h5>
-			<nav id="TableOfContents">
-				<ul>
-					{#each headings as { href, label }}
-						<li><a {href} class="block py-1">{label}</a></li>
-					{/each}
-				</ul>
-			</nav>
+{#if headings.length}
+	<div class="hidden flex-none pl-8 mr-8 w-64 xl:text-sm xl:block text-gray-500 dark:text-gray-400">
+		<div
+			class="flex flex-col justify-between overflow-y-auto sticky max-h-(screen-18) pt-10 pb-6 top-12"
+		>
+			<div class="mb-8">
+				<h5
+					class="mb-3 text-sm font-semibold tracking-wide text-gray-900 uppercase dark:text-white lg:text-xs"
+				>
+					On this page
+				</h5>
+				<nav id="TableOfContents">
+					<ul>
+						{#each headings as { href, label }}
+							<li><a {href} class="block py-1">{label}</a></li>
+						{/each}
+					</ul>
+				</nav>
+			</div>
 		</div>
 	</div>
-</div>
+{/if}

--- a/src/routes/utils/Htwo.svelte
+++ b/src/routes/utils/Htwo.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <h2
-	class="text-2xl w-full dark:text-white py-4"
+	class="htwo text-2xl w-full dark:text-white py-4"
 	on:mouseover={handleMouseover}
 	on:focus
 	on:mouseout={handleMouseout}


### PR DESCRIPTION
## 📑 Description
Fix to floating table of contents.
- selects only h2.htwo elements
- skips #References,#Related_components
- hides when empty


## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit/version

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
