### PR TITLE
Form buttons

### DIFF
--- a/src/lib/forms/Checkbox.svelte
+++ b/src/lib/forms/Checkbox.svelte
@@ -7,6 +7,7 @@
 	export let color: FormColorType = 'blue';
 	export let custom: boolean = false;
 	export let inline: boolean = false;
+	export let tinted: boolean = false;
 
 	export let group: string[] = [];
 	export let value: string = '';
@@ -38,10 +39,9 @@
 	<input
 		type="checkbox"
 		bind:checked
-		bind:group
+		on:click
 		{value}
 		{...$$restProps}
-		class={inputClass(custom, color, true, $$slots.default || $$restProps.class)}
-	/>
-	<slot />
+		class={inputClass(custom, color, true, tinted, $$slots.default || $$restProps.class)}
+	/><slot />
 </Label>

--- a/src/lib/forms/Checkbox.svelte
+++ b/src/lib/forms/Checkbox.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import type { FormColorType } from '../types';
-	import Radio from './Radio.svelte';
+	import Radio, { labelClass, inputClass } from './Radio.svelte';
+	import Label from './Label.svelte';
+
+	// properties forwarding
+	export let color: FormColorType = 'blue';
+	export let custom: boolean = false;
+	export let inline: boolean = false;
 
 	export let group: string[] = [];
 	export let value: string = '';
@@ -26,25 +32,16 @@
 			}
 		}
 	}
-
-	let inputClass; // get the value from the underlying Radio
-
-	// properties forwarding
-	export let custom: boolean = false;
-	export let color: FormColorType = 'blue';
-	export let inline: boolean = false;
-	export let tinted: boolean = false;
 </script>
 
-<Radio class={$$restProps.class} bind:inputClass {color} {custom} {inline} {tinted}>
+<Label class={labelClass(inline, $$restProps.class)} show={!!$$slots.default}>
 	<input
-		on:click
-		slot="input"
 		type="checkbox"
 		bind:checked
+		bind:group
 		{value}
 		{...$$restProps}
-		class="rounded {inputClass}"
+		class={inputClass(custom, color, true, $$slots.default || $$restProps.class)}
 	/>
 	<slot />
-</Radio>
+</Label>

--- a/src/lib/forms/Label.svelte
+++ b/src/lib/forms/Label.svelte
@@ -1,16 +1,38 @@
 <script lang="ts">
 	import classNames from 'classnames';
+
 	export let color: 'gray' | 'green' | 'red' | 'disabled' = 'gray';
-	export let labelClass: string = 'text-sm font-medium';
+	export let defaultClass: string = 'text-sm font-medium';
+
+	export let show: boolean = true; // helper for inheritance
+
 	const colorClasses = {
 		gray: 'text-gray-900 dark:text-gray-300',
 		green: 'text-green-700 dark:text-green-500',
 		red: 'text-red-700 dark:text-red-500',
 		disabled: 'text-gray-400 dark:text-gray-500'
 	};
+
+	function checkDisabled(node: HTMLLabelElement) {
+		const control: HTMLFormElement = node.control as HTMLFormElement;
+		color = control?.disabled ? 'disabled' : color;
+
+		return {
+			update() {
+				color = control?.disabled ? 'disabled' : color;
+			}
+		};
+	}
+
+	let labelClass;
+	$: labelClass = classNames(defaultClass, colorClasses[color], $$props.class);
 </script>
 
-<!-- svelte-ignore a11y-label-has-associated-control -->
-<label {...$$restProps} class={classNames(labelClass, colorClasses[color], $$props.class)}>
+{#if show}
+	<!-- svelte-ignore a11y-label-has-associated-control -->
+	<label {...$$restProps} class={labelClass} use:checkDisabled>
+		<slot />
+	</label>
+{:else}
 	<slot />
-</label>
+{/if}

--- a/src/lib/forms/Label.svelte
+++ b/src/lib/forms/Label.svelte
@@ -6,6 +6,8 @@
 
 	export let show: boolean = true; // helper for inheritance
 
+	let node: HTMLLabelElement;
+
 	const colorClasses = {
 		gray: 'text-gray-900 dark:text-gray-300',
 		green: 'text-green-700 dark:text-green-500',
@@ -13,15 +15,10 @@
 		disabled: 'text-gray-400 dark:text-gray-500'
 	};
 
-	function checkDisabled(node: HTMLLabelElement) {
-		const control: HTMLFormElement = node.control as HTMLFormElement;
+	// function checkDisabled(node: HTMLLabelElement) {
+	$: {
+		const control: HTMLInputElement = node?.control as HTMLInputElement;
 		color = control?.disabled ? 'disabled' : color;
-
-		return {
-			update() {
-				color = control?.disabled ? 'disabled' : color;
-			}
-		};
 	}
 
 	let labelClass;
@@ -30,9 +27,7 @@
 
 {#if show}
 	<!-- svelte-ignore a11y-label-has-associated-control -->
-	<label {...$$restProps} class={labelClass} use:checkDisabled>
-		<slot />
-	</label>
+	<label bind:this={node} {...$$restProps} class={labelClass}><slot /></label>
 {:else}
 	<slot />
 {/if}

--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -1,3 +1,32 @@
+<script context="module">
+	// this part is shared between Radio and Checkbox
+	import classNames from 'classnames';
+
+	const colorClasses = {
+		red: 'text-red-600 focus:ring-red-500 dark:focus:ring-red-600',
+		green: 'text-green-600 focus:ring-green-500 dark:focus:ring-green-600',
+		purple: 'text-purple-600 focus:ring-purple-500 dark:focus:ring-purple-600',
+		teal: 'text-teal-600 focus:ring-teal-500 dark:focus:ring-teal-600',
+		yellow: 'text-yellow-400 focus:ring-yellow-500 dark:focus:ring-yellow-600',
+		orange: 'text-orange-500 focus:ring-orange-500 dark:focus:ring-orange-600',
+		blue: 'text-blue-600 focus:ring-blue-500 dark:focus:ring-blue-600'
+	};
+	const defaultInputClass =
+		'w-4 h-4 bg-gray-100 border-gray-300 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 mr-2';
+
+	export const labelClass = (inline, extraClass) =>
+		classNames(inline ? 'inline-flex' : 'flex', 'items-center', extraClass);
+
+	export const inputClass = (custom, color, rounded, extraClass) =>
+		classNames(
+			defaultInputClass,
+			custom && 'sr-only peer',
+			rounded && 'rounded',
+			colorClasses[color],
+			extraClass
+		);
+</script>
+
 <script lang="ts">
 	/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Label
 
@@ -12,58 +41,25 @@
 	</label>
 
 	 */
-	import classNames from 'classnames';
+
 	import type { FormColorType } from '../types';
+	import Label from './Label.svelte';
 
 	export let color: FormColorType = 'blue';
 	export let custom: boolean = false;
 	export let inline: boolean = false;
-	export let tinted: boolean = false;
 
 	export let group: number | string = '';
 	export let value: string = '';
-
-	export let inputClass: string;
-	$: inputClass = classNames(
-		'w-4 h-4 bg-gray-100 border-gray-300 dark:ring-offset-gray-800 focus:ring-2 mr-2',
-		tinted ? 'dark:bg-gray-600 dark:border-gray-500' : 'dark:bg-gray-700 dark:border-gray-600',
-		custom && 'sr-only peer',
-		colorClasses[color]
-	);
-
-	let colorLabel: 'gray' | 'green' | 'red' | 'disabled' = 'gray';
-	$: colorLabel = $$restProps.disabled ? 'disabled' : colorLabel;
-
-	let labelClass;
-	$: labelClass = classNames(
-		inline ? 'inline-flex' : 'flex',
-		'items-center text-sm font-medium',
-		colorClassesLabel[colorLabel],
-		$$restProps.class
-	);
-
-	const colorClassesLabel = {
-		gray: 'text-gray-900 dark:text-gray-300',
-		green: 'text-green-700 dark:text-green-500',
-		red: 'text-red-700 dark:text-red-500',
-		disabled: 'text-gray-400 dark:text-gray-500'
-	};
-
-	const colorClasses = {
-		red: 'text-red-600 focus:ring-red-500 dark:focus:ring-red-600',
-		green: 'text-green-600 focus:ring-green-500 dark:focus:ring-green-600',
-		purple: 'text-purple-600 focus:ring-purple-500 dark:focus:ring-purple-600',
-		teal: 'text-teal-600 focus:ring-teal-500 dark:focus:ring-teal-600',
-		yellow: 'text-yellow-400 focus:ring-yellow-500 dark:focus:ring-yellow-600',
-		orange: 'text-orange-500 focus:ring-orange-500 dark:focus:ring-orange-600',
-		blue: 'text-blue-600 focus:ring-blue-500 dark:focus:ring-blue-600'
-	};
 </script>
 
-<!-- svelte-ignore a11y-label-has-associated-control -->
-<label class={labelClass}>
-	<slot name="input">
-		<input on:click type="radio" bind:group {value} {...$$restProps} class={inputClass} />
-	</slot>
+<Label class={labelClass(inline, $$restProps.class)} show={!!$$slots.default}>
+	<input
+		type="radio"
+		bind:group
+		{value}
+		{...$$restProps}
+		class={inputClass(custom, color, false, $$slots.default || $$restProps.class)}
+	/>
 	<slot />
-</label>
+</Label>

--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -11,15 +11,14 @@
 		orange: 'text-orange-500 focus:ring-orange-500 dark:focus:ring-orange-600',
 		blue: 'text-blue-600 focus:ring-blue-500 dark:focus:ring-blue-600'
 	};
-	const defaultInputClass =
-		'w-4 h-4 bg-gray-100 border-gray-300 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 mr-2';
 
 	export const labelClass = (inline, extraClass) =>
 		classNames(inline ? 'inline-flex' : 'flex', 'items-center', extraClass);
 
-	export const inputClass = (custom, color, rounded, extraClass) =>
+	export const inputClass = (custom, color, rounded, tinted, extraClass) =>
 		classNames(
-			defaultInputClass,
+			'w-4 h-4 bg-gray-100 border-gray-300 dark:ring-offset-gray-800 focus:ring-2 mr-2',
+			tinted ? 'dark:bg-gray-600 dark:border-gray-500' : 'dark:bg-gray-700 dark:border-gray-600',
 			custom && 'sr-only peer',
 			rounded && 'rounded',
 			colorClasses[color],
@@ -28,26 +27,13 @@
 </script>
 
 <script lang="ts">
-	/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Label
-
-	To associate the <label> with an <input> element, you need to give the <input> an id attribute.
-	The <label> then needs a for attribute	whose value is the same as the input's id.
-
-	Alternatively, you can nest the <input> directly inside the <label>, in which case the for and
-	id attributes are not needed because the association is implicit:
-
-	<label>Do you like peas?
-	<input type="checkbox" name="peas">
-	</label>
-
-	 */
-
 	import type { FormColorType } from '../types';
 	import Label from './Label.svelte';
 
 	export let color: FormColorType = 'blue';
 	export let custom: boolean = false;
 	export let inline: boolean = false;
+	export let tinted: boolean = false;
 
 	export let group: number | string = '';
 	export let value: string = '';
@@ -57,9 +43,9 @@
 	<input
 		type="radio"
 		bind:group
+		on:click
 		{value}
 		{...$$restProps}
-		class={inputClass(custom, color, false, $$slots.default || $$restProps.class)}
-	/>
-	<slot />
+		class={inputClass(custom, color, false, tinted, $$slots.default || $$restProps.class)}
+	/><slot />
 </Label>

--- a/src/lib/forms/Toggle.svelte
+++ b/src/lib/forms/Toggle.svelte
@@ -24,7 +24,7 @@
 	};
 </script>
 
-<Checkbox on:click custom class="relative {$$restProps.class}" {...$$restProps}>
+<Checkbox custom class="relative {$$restProps.class}" {...$$restProps}>
 	<div class={classNames(common, colors[$$restProps.color ?? 'blue'], sizes[size])} />
 	<slot />
 </Checkbox>

--- a/src/lib/forms/Toggle.svelte
+++ b/src/lib/forms/Toggle.svelte
@@ -24,7 +24,7 @@
 	};
 </script>
 
-<Checkbox custom class="relative {$$restProps.class}" {...$$restProps}>
+<Checkbox custom class="relative {$$restProps.class}" {...$$restProps} on:click>
 	<div class={classNames(common, colors[$$restProps.color ?? 'blue'], sizes[size])} />
 	<slot />
 </Checkbox>

--- a/src/routes/forms/checkbox.md
+++ b/src/routes/forms/checkbox.md
@@ -8,6 +8,7 @@ layout: formLayout
   import TableProp from '../utils/TableProp.svelte'
   import TableDefaultRow from '../utils/TableDefaultRow.svelte'
   import { Checkbox, Breadcrumb, BreadcrumbItem, Label, Helper } from "$lib/index"
+  import { Table, TableBody, TableBodyRow, TableBodyCell, TableHead, TableHeadCell } from "$lib/index"
   import { Home } from 'svelte-heros'
   import componentProps from '../props/Radio.json'
   import componentProps2 from '../props/Label.json'
@@ -59,6 +60,56 @@ The checkbox component can be used to receive one or more selected options from 
 ```html
 <Checkbox disabled class="mb-4">Disabled checkbox</Checkbox>
 <Checkbox disabled checked>Disabled checkbox</Checkbox>
+```
+
+<Htwo label="Alternative syntax" />
+
+If you need separate control over the label and the checkbox you can use the verbose syntax, but then you need to take care about aligning manually.
+
+<ExampleDiv>
+  <Table>
+  <TableHead>
+    <TableHeadCell>Left column</TableHeadCell>
+    <TableHeadCell>Right column</TableHeadCell>
+  </TableHead>
+  <TableBody class="divide-y dark:divide-gray-700">
+    <TableBodyRow class="divide-x dark:divide-gray-700">
+      <TableBodyCell><Label for="checkbox1">Default checkbox</Label></TableBodyCell>
+      <TableBodyCell><Label for="checkbox2">Disabled checkbox</Label></TableBodyCell>
+    </TableBodyRow>
+    <TableBodyRow class="divide-x dark:divide-gray-700">
+      <TableBodyCell><Checkbox id="checkbox1" /></TableBodyCell>
+      <TableBodyCell><Checkbox id="checkbox2" disabled/></TableBodyCell>
+    </TableBodyRow>
+  </TableBody>
+  </Table>
+
+  <Label color='red' class="mt-4 flex items-center font-bold italic">
+    Label on the other side <Checkbox class="ml-2"/>
+  </Label>
+</ExampleDiv>
+
+```html
+  <Table>
+    <TableHead>
+      <TableHeadCell>Left column</TableHeadCell>
+      <TableHeadCell>Right column</TableHeadCell>
+    </TableHead>
+    <TableBody class="divide-y">
+      <TableBodyRow class="divide-x dark:divide-gray-700">
+        <TableBodyCell><Label for="checkbox1">Default checkbox</Label></TableBodyCell>
+        <TableBodyCell><Label for="checkbox2">Disabled checkbox</Label></TableBodyCell>
+      </TableBodyRow>
+      <TableBodyRow class="divide-x dark:divide-gray-700">
+        <TableBodyCell><Checkbox id="checkbox1" /></TableBodyCell>
+        <TableBodyCell><Checkbox id="checkbox2" disabled/></TableBodyCell>
+      </TableBodyRow>
+    </TableBody>
+  </Table>
+
+  <Label color='red' class="mt-4 flex items-center font-bold italic">
+    Label on the other side <Checkbox class="ml-2"/>
+  </Label>
 ```
 
 <Htwo label="Checkbox with a link" />

--- a/src/routes/forms/radio.md
+++ b/src/routes/forms/radio.md
@@ -7,7 +7,8 @@ layout: formLayout
   import ExampleDiv from '../utils/ExampleDiv.svelte'
   import TableProp from '../utils/TableProp.svelte'
   import TableDefaultRow from '../utils/TableDefaultRow.svelte'
-  import { Radio, Breadcrumb, BreadcrumbItem, Helper } from "$lib/index"
+  import { Radio, Breadcrumb, BreadcrumbItem, Label, Helper } from "$lib/index"
+  import { Table, TableBody, TableBodyRow, TableBodyCell, TableHead, TableHeadCell } from "$lib/index"
   import { Home } from 'svelte-heros'
   import componentProps from '../props/Radio.json'
   import componentProps2 from '../props/Label.json'
@@ -64,6 +65,57 @@ Apply the `disabled` attribute to the radio component to disallow the selection 
 ```html
 <Radio name="disabled-state" disabled class="mb-4">Disabled radio</Radio>
 <Radio name="disabled-state" disabled checked>Disabled radio</Radio>
+```
+
+
+<Htwo label="Alternative syntax" />
+
+If you need separate control over the label and the radio you can use the verbose syntax, but then you need to take care about aligning manually.
+
+<ExampleDiv>
+  <Table>
+  <TableHead>
+    <TableHeadCell>Left column</TableHeadCell>
+    <TableHeadCell>Right column</TableHeadCell>
+  </TableHead>
+  <TableBody class="divide-y dark:divide-gray-700">
+    <TableBodyRow class="divide-x dark:divide-gray-700">
+      <TableBodyCell><Label for="radio1">Default radio</Label></TableBodyCell>
+      <TableBodyCell><Label for="radio2">Disabled radio</Label></TableBodyCell>
+    </TableBodyRow>
+    <TableBodyRow class="divide-x dark:divide-gray-700">
+      <TableBodyCell><Radio name="separate" id="radio1" /></TableBodyCell>
+      <TableBodyCell><Radio name="separate" id="radio2" disabled/></TableBodyCell>
+    </TableBodyRow>
+  </TableBody>
+  </Table>
+
+  <Label color='red' class="mt-4 flex items-center font-bold italic">
+    Label on the other side <Radio name="separate" class="ml-2"/>
+  </Label>
+</ExampleDiv>
+
+```html
+  <Table>
+    <TableHead>
+      <TableHeadCell>Left column</TableHeadCell>
+      <TableHeadCell>Right column</TableHeadCell>
+    </TableHead>
+    <TableBody class="divide-y">
+      <TableBodyRow class="divide-x dark:divide-gray-700">
+        <TableBodyCell><Label for="radio1">Default radio</Label></TableBodyCell>
+        <TableBodyCell><Label for="radio2">Disabled radio</Label></TableBodyCell>
+      </TableBodyRow>
+      <TableBodyRow class="divide-x dark:divide-gray-700">
+        <TableBodyCell><Radio name="separate" id="radio1" /></TableBodyCell>
+        <TableBodyCell><Radio name="separate" id="radio2" disabled/></TableBodyCell>
+      </TableBodyRow>
+    </TableBody>
+  </Table>
+
+  <Label color='red' class="mt-4 flex items-center font-bold italic">
+    Label on the other side <Checkbox class="ml-2"/>
+  </Label>
 ```
 
 <Htwo label="Radio with a link" />


### PR DESCRIPTION
## 📑 Description
Form buttons: Radio, Checkbox, Toggle rewritten again. 

I can't make the svelte component 'inheritance' work well so needed another code structure.

Svelte compiler is strict in checking the binding and does not allow `bind:checked` to `input type="radio"`.

On the other hand there's a known svelte bug of not properly handling `bind:group` for `input type="checkbox"` when it's wrapped in the custom component.

The above prevents in practice the usage of one file all input types support.

This PR adds as well a follow `disable` to the label component so it is not needed to handle that in checkbox or radio.

Toggle is just a special case of checkbox and is implemented as `<Checkbox custom={true} ...`.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit/version


## ℹ Additional Information
`on:click` is not omitted this time.
