### PR TITLE
forms-buttons: missing examples and tuning

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -4,6 +4,7 @@
 	import classNames from 'classnames';
 	import { ChevronUp, ChevronRight, ChevronDown, ChevronLeft } from 'svelte-heros';
 	import type { Placement } from '@floating-ui/dom';
+
 	export let label: string = '';
 	export let inline: boolean = false;
 	export let tooltipArrow: boolean = false;
@@ -39,14 +40,7 @@
 				{/if}
 			</button>
 		{:else}
-			<Button
-				pill={$$props.pill}
-				outline={$$props.outline}
-				color={$$props.color}
-				size={$$props.size}
-				icon={$$props.icon}
-				gradient={$$props.gradient}
-			>
+			<Button {...$$restProps}>
 				<slot name="label">{label}</slot>
 				{#if arrowIcon}
 					<svelte:component this={icon ?? ChevronDown} class="ml-2 h-4 w-4" />

--- a/src/lib/forms/SimpleSearch.svelte
+++ b/src/lib/forms/SimpleSearch.svelte
@@ -5,10 +5,11 @@
 	export let iconDivClass: string =
 		'flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none';
 	export let inputClass: string =
-		'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500';
+		'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 p-2.5 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500';
 	export let btnClass: string =
 		'p-2.5 ml-2 text-sm font-medium text-white bg-blue-700 rounded-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800';
 	export let placeholder: string = 'Search';
+	export let tinted: boolean = false;
 </script>
 
 <form class="flex items-center" on:submit>
@@ -27,7 +28,15 @@
 				/></svg
 			>
 		</div>
-		<input {...$$restProps} type="text" {id} class={inputClass} {placeholder} />
+		<input
+			{...$$restProps}
+			type="text"
+			{id}
+			class="{tinted
+				? 'dark:bg-gray-600 dark:border-gray-500'
+				: ' dark:bg-gray-700 dark:border-gray-600'} {inputClass}"
+			{placeholder}
+		/>
 	</div>
 	<button type="submit" class={btnClass}
 		><svg

--- a/src/routes/dropdowns/index.md
+++ b/src/routes/dropdowns/index.md
@@ -183,7 +183,7 @@ Add multiple checkbox elements inside your dropdown menu to enable more advanced
 </Dropdown>
 ```
 
-<Htwo label="Background hover" />
+<Htwo label="Checkbox: Background hover" />
 
 Use this example to update the background color of a menu item when using a list of checkbox elements.
 
@@ -222,47 +222,45 @@ Use this example to update the background color of a menu item when using a list
 ```
 
 
-<Htwo label="Helper text" />
+<Htwo label="Checkbox: Helper text" />
 
 Add an extra helper text to each checkbox element inside the dropdown menu list with this example.
 
 
 <ExampleDiv class="flex justify-center h-96">
-<Dropdown class="w-64" >
-  <span slot="label" class="w-48">Dropdown checkbox</span>
-  <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Enable notifications</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted checked>Enable 2FA auth</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Subscribe newsletter</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-  </ul>
-</Dropdown>
+  <Dropdown label="Dropdown checkbox" class="w-60" >
+    <ul slot="content" class="p-3 space-y-1">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Enable notifications</Checkbox>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted checked>Enable 2FA auth</Checkbox>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Subscribe newsletter</Checkbox>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+    </ul>
+  </Dropdown>
 </ExampleDiv>
 
 
 ```html
-<Dropdown class="w-64">
-  <Button slot="trigger" class="w-64">Dropdown checkbox <ChevronDown size="18" class="ml-2" /></Button>
+<Dropdown label="Dropdown checkbox" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox tinted>Enable notifications</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox tinted checked>Enable 2FA auth</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox tinted>Subscribe newsletter</Checkbox>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
   </ul>
 </Dropdown>
@@ -305,7 +303,7 @@ Add multiple radio elements inside your dropdown menu to enable more advanced in
 </Dropdown>
 ```
 
-<Htwo label="Background hover" />
+<Htwo label="Radio: Background hover" />
 
 Use this example to update the background color of a menu item when using a list of radio elements.
 
@@ -348,47 +346,45 @@ Use this example to update the background color of a menu item when using a list
 ```
 
 
-<Htwo label="Helper text" />
+<Htwo label="Radio: Helper text" />
 
 Add an extra helper text to each radio element inside the dropdown menu list with this example.
 
 
 <ExampleDiv class="flex justify-center h-96">
-<Dropdown class="w-64" >
-  <span slot="label" class="w-48">Dropdown radio</span>
-  <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={1} tinted>Enable notifications</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={2} tinted>Enable 2FA auth</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={3} tinted>Subscribe newsletter</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
-    </DropdownItem>
-  </ul>
-</Dropdown>
+  <Dropdown label="Dropdown radio" class="w-60" >
+    <ul slot="content" class="p-3 space-y-1">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio bind:group={group3} value={1} tinted>Enable notifications</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio bind:group={group3} value={2} tinted>Enable 2FA auth</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio bind:group={group3} value={3} tinted>Subscribe newsletter</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+    </ul>
+  </Dropdown>
 </ExampleDiv>
 
 
 ```html
-<Dropdown class="w-64">
-  <Button slot="trigger" class="w-64">Dropdown radio <ChevronDown size="18" class="ml-2" /></Button>
+<Dropdown label="Dropdown radio" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={1} tinted>Enable notifications</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={2} tinted>Enable 2FA auth</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={3} tinted>Subscribe newsletter</Radio>
-      <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
   </ul>
 </Dropdown>
@@ -497,81 +493,61 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 This example can be used when you want to show a long list of items that won’t affect the height of the dropdown menu by enabling a scrolling behaviour.
 
 <ExampleDiv class="flex justify-center h-80">
-<Dropdown label="Project users" class="w-48">
-  <svelte:fragment slot="content">
-  <ul class="overflow-y-auto py-1 h-48 text-gray-700 dark:text-gray-200">
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-  </ul>
-  <DropdownDivider/>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2" color="red">
-      <UserAdd class="h-5 w-5"/>Add new user
-    </DropdownItem>
-  </svelte:fragment>
-</Dropdown>
+  <Dropdown label="Project users" class="w-48">
+    <svelte:fragment slot="content">
+      <ul class="overflow-y-auto py-1 h-48 text-gray-700 dark:text-gray-200">
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-1.webp" size="xs"/>Robert Wall
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-2.webp" size="xs"/>Joseph Mcfall
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-3.webp" size="xs"/>Leslie Livingston
+        </DropdownItem>
+      </ul>
+      <a href="/" class="flex items-center p-3 text-sm font-medium text-blue-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-blue-500 hover:underline">
+          <UserAdd class="h-5 w-5 mr-1"/>Add new user
+      </a>
+    </svelte:fragment>
+  </Dropdown>
 </ExampleDiv>
 
 ```html
 <Dropdown label="Project users" class="w-48">
   <svelte:fragment slot="content">
-  <ul class="overflow-y-auto py-1 h-48 text-gray-700 dark:text-gray-200">
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
-    </DropdownItem>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2">
-      <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
-    </DropdownItem>
-  </ul>
-  <DropdownDivider/>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2" color="red">
-      <UserAdd class="h-5 w-5"/>Add new user
-    </DropdownItem>
+      <ul class="overflow-y-auto py-1 h-48 text-gray-700 dark:text-gray-200">
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-1.webp" size="xs"/>Jese Leos
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-2.webp" size="xs"/>Robert Gouth
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-3.webp" size="xs"/>Bonnie Green
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-1.webp" size="xs"/>Robert Wall
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-2.webp" size="xs"/>Joseph Mcfall
+        </DropdownItem>
+        <DropdownItem class="flex items-center text-base font-semibold gap-2">
+          <Avatar src="/images/profile-picture-3.webp" size="xs"/>Leslie Livingston
+        </DropdownItem>
+      </ul>
+    <a href="/" class="flex items-center p-3 text-sm font-medium text-blue-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-blue-500 hover:underline">
+        <UserAdd class="h-5 w-5 mr-1"/>Add new user
+    </a>
   </svelte:fragment>
 </Dropdown>
 ```
@@ -581,68 +557,67 @@ This example can be used when you want to show a long list of items that won’t
 Use this example if you want to add a search bar inside the dropdown menu to be able to filter through a long list of menu items with scrolling behaviour.
 
 <ExampleDiv class="flex justify-center h-96">
-<Dropdown label="Project users" class="w-64">
+<Dropdown label="Project users" class="w-60">
   <svelte:fragment slot="content">
-  <div class="p-3 text-gray-700 dark:text-gray-200 dark:bg-gray-800">
-    <SimpleSearch btnClass="hidden"/>
-  </div>
-  <ul class="overflow-y-auto p-3 space-y-1 h-48">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Jese Leos</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Robert Gouth</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted checked>Bonnie Green</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Jese Leos</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Robert Gouth</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Bonnie Green</Checkbox>
-    </DropdownItem>
-  </ul>
-  <DropdownItem class="flex items-center text-base font-semibold gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 hover:underline" color="red">
-    <UserRemove class="w-5 h-5" />Delete user
-  </DropdownItem>
+    <div class="p-3">
+      <SimpleSearch btnClass="hidden" tinted/>
+    </div>
+    <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Jese Leos</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Robert Gouth</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted checked>Bonnie Green</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Jese Leos</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Robert Gouth</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Bonnie Green</Checkbox>
+      </DropdownItem>
+    </ul>
+    <a href="/" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">
+        <UserRemove class="w-5 h-5 mr-1" />Delete user
+    </a>
   </svelte:fragment>
 </Dropdown>
 </ExampleDiv>
 
 ```html
-<Dropdown label="Project users" class="w-48">
+<Dropdown label="Project users" class="w-60">
   <svelte:fragment slot="content">
-  <div class="p-3 text-gray-700 dark:text-gray-200 dark:bg-gray-800">
-    <SimpleSearch btnClass="hidden"/>
-  </div>
-  <ul class="overflow-y-auto p-3 space-y-1 h-48">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Jese Leos</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Robert Gouth</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted checked>Bonnie Green</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Jese Leos</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Robert Gouth</Checkbox>
-    </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Bonnie Green</Checkbox>
-    </DropdownItem>
-  </ul>
-  <DropdownDivider/>
-    <DropdownItem class="flex items-center text-base font-semibold gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 hover:underline" color="red">
-      <UserRemove class="w-5 h-5" />Delete user
-    </DropdownItem>
+    <div class="p-3">
+      <SimpleSearch btnClass="hidden" tinted/>
+    </div>
+    <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Jese Leos</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Robert Gouth</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted checked>Bonnie Green</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Jese Leos</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Robert Gouth</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Bonnie Green</Checkbox>
+      </DropdownItem>
+    </ul>
+    <a href="#" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">
+        <UserRemove class="w-5 h-5 mr-1" />Delete user
+    </a>
   </svelte:fragment>
 </Dropdown>
 ```

--- a/src/routes/forms/checkbox.md
+++ b/src/routes/forms/checkbox.md
@@ -7,9 +7,9 @@ layout: formLayout
   import ExampleDiv from '../utils/ExampleDiv.svelte'
   import TableProp from '../utils/TableProp.svelte'
   import TableDefaultRow from '../utils/TableDefaultRow.svelte'
-  import { Checkbox, Breadcrumb, BreadcrumbItem, Label, Helper } from "$lib/index"
+  import { Checkbox, Breadcrumb, BreadcrumbItem, Dropdown, DropdownItem, DropdownDivider, SimpleSearch, Label, Helper } from "$lib/index"
   import { Table, TableBody, TableBodyRow, TableBodyCell, TableHead, TableHeadCell } from "$lib/index"
-  import { Home } from 'svelte-heros'
+  import { Home, UserRemove } from 'svelte-heros'
   import componentProps from '../props/Radio.json'
   import componentProps2 from '../props/Label.json'
   import componentProps3 from '../props/Helper.json'
@@ -34,8 +34,8 @@ The checkbox component can be used to receive one or more selected options from 
 
 <Htwo label="Checkbox examples" />
 
-<ExampleDiv>
-<Checkbox class="mb-4">Default checkbox</Checkbox>
+<ExampleDiv class="flex flex-col gap-4">
+<Checkbox>Default checkbox</Checkbox>
 <Checkbox checked >Checked state</Checkbox>
 </ExampleDiv>
 
@@ -44,7 +44,7 @@ The checkbox component can be used to receive one or more selected options from 
 	import { Checkbox, Label, Helper } from 'flowbite-svelte';
 </script>
 
-<Checkbox class="mb-4">Default checkbox</Checkbox>
+<Checkbox>Default checkbox</Checkbox>
 <Checkbox checked>Checked state</Checkbox>
 ```
 
@@ -52,14 +52,14 @@ The checkbox component can be used to receive one or more selected options from 
 
 <p>This example can be used for the disabled state of the checkbox component by applying the disabled attribute to the input element.</p>
 
-<ExampleDiv>
-<Checkbox disabled class="mb-4">Disabled checkbox</Checkbox>
-<Checkbox disabled checked >Disabled checkbox</Checkbox>
+<ExampleDiv class="flex flex-col gap-4">
+<Checkbox disabled>Disabled checkbox</Checkbox>
+<Checkbox disabled checked >Disabled checked</Checkbox>
 </ExampleDiv>
 
 ```html
-<Checkbox disabled class="mb-4">Disabled checkbox</Checkbox>
-<Checkbox disabled checked>Disabled checkbox</Checkbox>
+<Checkbox disabled>Disabled checkbox</Checkbox>
+<Checkbox disabled checked>Disabled checked</Checkbox>
 ```
 
 <Htwo label="Alternative syntax" />
@@ -132,12 +132,12 @@ If you need separate control over the label and the checkbox you can use the ver
 
 <ExampleDiv>
   <Checkbox aria-describedby="helper-checkbox-text">Free shipping via Flowbite</Checkbox>
-  <Helper id="helper-checkbox-text" class="ml-6">For orders shipped from $25 in books or $29 in other categories</Helper>
+  <Helper id="helper-checkbox-text" class="pl-6 -mt-1">For orders shipped from $25 in books or $29 in other categories</Helper>
 </ExampleDiv>
 
 ```html
   <Checkbox aria-describedby="helper-checkbox-text">Free shipping via Flowbite</Checkbox>
-  <Helper id="helper-checkbox-text" class="ml-6">For orders shipped from $25 in books or $29 in other categories</Helper>
+  <Helper id="helper-checkbox-text" class="pl-6 -mt-1">For orders shipped from $25 in books or $29 in other categories</Helper>
 ```
 
 <Htwo label="Bordered" />
@@ -213,15 +213,77 @@ Use this example to show a list of checkbox items inside a card horizontally.
 </ul>
 ```
 
-<!--
+
 <Htwo label="Checkbox dropdown" />
 
 Use this example to show a list of checkbox items inside a dropdown menu.
 
-<ExampleDiv>
-To do.
+
+<ExampleDiv class="flex justify-center h-96">
+  <Dropdown label="Dropdown search" class="w-60">
+    <svelte:fragment slot="content">
+      <div class="p-3">
+        <SimpleSearch btnClass="hidden" tinted/>
+      </div>
+      <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted>Jese Leos</Checkbox>
+        </DropdownItem>
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted>Robert Gouth</Checkbox>
+        </DropdownItem>
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted checked>Bonnie Green</Checkbox>
+        </DropdownItem>
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted>Joseph Mcfall</Checkbox>
+        </DropdownItem>
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted>Leslie Livingston</Checkbox>
+        </DropdownItem>
+        <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+          <Checkbox tinted>Roberta Casas</Checkbox>
+        </DropdownItem>
+      </ul>
+      <a href="#" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">
+          <UserRemove class="w-5 h-5 mr-1" /> Delete user
+      </a>
+    </svelte:fragment>
+  </Dropdown>
 </ExampleDiv>
--->
+
+```html
+<Dropdown label="Project users" class="w-60">
+  <svelte:fragment slot="content">
+    <div class="p-3">
+      <SimpleSearch btnClass="hidden" tinted/>
+    </div>
+    <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Jese Leos</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Robert Gouth</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted checked>Bonnie Green</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Joseph Mcfall</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Leslie Livingston</Checkbox>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Checkbox tinted>Roberta Casas</Checkbox>
+      </DropdownItem>
+    </ul>
+    <a href="#" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">
+        <UserRemove class="w-5 h-5 mr-1" /> Delete user
+    </a>
+  </svelte:fragment>
+</Dropdown>
+``
 
 <Htwo label="Inline layout" />
 

--- a/src/routes/forms/radio.md
+++ b/src/routes/forms/radio.md
@@ -7,7 +7,7 @@ layout: formLayout
   import ExampleDiv from '../utils/ExampleDiv.svelte'
   import TableProp from '../utils/TableProp.svelte'
   import TableDefaultRow from '../utils/TableDefaultRow.svelte'
-  import { Radio, Breadcrumb, BreadcrumbItem, Label, Helper } from "$lib/index"
+  import { Radio, Breadcrumb, BreadcrumbItem, Dropdown, DropdownItem, Label, Helper } from "$lib/index"
   import { Table, TableBody, TableBodyRow, TableBodyCell, TableHead, TableHeadCell } from "$lib/index"
   import { Home } from 'svelte-heros'
   import componentProps from '../props/Radio.json'
@@ -37,8 +37,8 @@ The radio component can be used to allow the user to choose a single option from
 
 <Htwo label="Radio examples" />
 
-<ExampleDiv>
-<Radio name="example" class="mb-4">Default radio</Radio>
+<ExampleDiv class="flex flex-col gap-4">
+<Radio name="example">Default radio</Radio>
 <Radio name="example" checked={true}>Checked state</Radio>
 </ExampleDiv>
 
@@ -47,7 +47,7 @@ The radio component can be used to allow the user to choose a single option from
 	import { Radio, Label, Helper } from 'flowbite-svelte';
 </script>
 
-<Radio name="example" class="mb-4">Default radio</Radio>
+<Radio name="example">Default radio</Radio>
 <Radio name="example" checked>Checked state</Radio>
 ```
 
@@ -57,14 +57,14 @@ Apply the `disabled` attribute to the radio component to disallow the selection 
 
 <p>This example can be used for the disabled state of the radio component by applying the disabled attribute to the input element.</p>
 
-<ExampleDiv>
-<Radio name="disabled-state" disabled class="mb-4">Disabled radio</Radio>
+<ExampleDiv class="flex flex-col gap-4">
+<Radio name="disabled-state" disabled>Disabled radio</Radio>
 <Radio name="disabled-state" disabled checked >Disabled checked</Radio>
 </ExampleDiv>
 
 ```html
-<Radio name="disabled-state" disabled class="mb-4">Disabled radio</Radio>
-<Radio name="disabled-state" disabled checked>Disabled radio</Radio>
+<Radio name="disabled-state" disabled>Disabled radio</Radio>
+<Radio name="disabled-state" disabled checked>Disabled checked</Radio>
 ```
 
 
@@ -138,12 +138,12 @@ If you need separate control over the label and the radio you can use the verbos
 
 <ExampleDiv>
   <Radio aria-describedby="helper-checkbox-text">Free shipping via Flowbite</Radio>
-  <Helper id="helper-checkbox-text" class="ml-6">For orders shipped from $25 in books or $29 in other categories</Helper>
+  <Helper id="helper-checkbox-text" class="pl-6 -mt-1">For orders shipped from $25 in books or $29 in other categories</Helper>
 </ExampleDiv>
 
 ```html
   <Radio aria-describedby="helper-checkbox-text">Free shipping via Flowbite</Radio>
-  <Helper id="helper-checkbox-text" class="ml-6">For orders shipped from $25 in books or $29 in other categories</Helper>
+  <Helper id="helper-checkbox-text" class="pl-6 -mt-1">For orders shipped from $25 in books or $29 in other categories</Helper>
 ```
 
 <Htwo label="Bordered" />
@@ -222,15 +222,47 @@ Use this example to show a list of radio items inside a card horizontally.
 </ul>
 ```
 
-<!--
-<Htwo label="Radio dropdown" />
+<Htwo label="Radio in dropdown" />
 
-Use this example to show a list of radio items inside a dropdown menu.
+Here’s an example of a list group that you can use right away.
 
-<ExampleDiv>
-To do.
+<ExampleDiv class="flex justify-center h-96">
+  <Dropdown label="Dropdown radio" class="w-60" >
+    <ul slot="content" class="p-3">
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio name="dropdown" value={1} tinted>Individual</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio name="dropdown" value={2} tinted>Company</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+        <Radio name="dropdown" value={3} tinted>Non profit</Radio>
+        <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+      </DropdownItem>
+    </ul>
+  </Dropdown>
 </ExampleDiv>
--->
+
+```html
+<Dropdown label="Dropdown radio" class="w-60" >
+  <ul slot="content" class="p-3">
+    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <Radio name="dropdown" value={1} tinted>Individual</Radio>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+    </DropdownItem>
+    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <Radio name="dropdown" value={2} tinted>Company</Radio>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+    </DropdownItem>
+    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <Radio name="dropdown" value={3} tinted>Non profit</Radio>
+      <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
+    </DropdownItem>
+  </ul>
+</Dropdown>
+```
 
 <Htwo label="Inline layout" />
 


### PR DESCRIPTION
## 📑 Description
- Added [Radio in dropdown](https://flowbite.com/docs/forms/radio/#radio-in-dropdown) and [Checkbox in dropdown](https://flowbite.com/docs/forms/checkbox/#checkbox-dropdown)
- Format adjustments to Search example in Dropdown
- Dropdown - floating menu added Radio/Checkbox prefixes to sections.
- Some other polishing here and there

Flowbite introduces anomaly of dark colors when forms are put on another component. This is visible when Checkbox or Radio is put on Dropdown for example. That's why I've added `tinted` property to those.
I needed to add `tinted` property to `SimpleSearch` for the same reason.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit/version

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
