### PR TITLE
feat: form buttons tinted removed

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { setContext } from 'svelte';
 	import Tooltip from '$lib/tooltips/Tooltip.svelte';
 	import Button from '$lib/buttons/Button.svelte';
 	import classNames from 'classnames';
@@ -12,6 +13,8 @@
 	export let labelClass: string =
 		'flex items-center justify-between w-full py-2 pl-3 pr-4 font-medium text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-gray-400 dark:hover:text-white dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent';
 	export let placement: 'auto' | Placement = 'bottom';
+
+	setContext('background', true);
 
 	const icons = {
 		top: ChevronUp,

--- a/src/lib/forms/Checkbox.svelte
+++ b/src/lib/forms/Checkbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
 	import type { FormColorType } from '../types';
 	import Radio, { labelClass, inputClass } from './Radio.svelte';
 	import Label from './Label.svelte';
@@ -7,11 +8,13 @@
 	export let color: FormColorType = 'blue';
 	export let custom: boolean = false;
 	export let inline: boolean = false;
-	export let tinted: boolean = false;
 
 	export let group: string[] = [];
 	export let value: string = '';
 	export let checked: boolean = undefined;
+
+	// tinted if put in component having its own background
+	let background: boolean = getContext('background');
 
 	$: {
 		// There's a bug in Svelte and bind:group is not working with wrapped checkbox
@@ -42,6 +45,6 @@
 		on:click
 		{value}
 		{...$$restProps}
-		class={inputClass(custom, color, true, tinted, $$slots.default || $$props.class)}
+		class={inputClass(custom, color, true, background, $$slots.default || $$props.class)}
 	/><slot />
 </Label>

--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -27,16 +27,19 @@
 </script>
 
 <script lang="ts">
+	import { getContext } from 'svelte';
 	import type { FormColorType } from '../types';
 	import Label from './Label.svelte';
 
 	export let color: FormColorType = 'blue';
 	export let custom: boolean = false;
 	export let inline: boolean = false;
-	export let tinted: boolean = false;
 
 	export let group: number | string = '';
 	export let value: string = '';
+
+	// tinted if put in component having its own background
+	let background: boolean = getContext('background');
 </script>
 
 <Label class={labelClass(inline, $$props.class)} show={!!$$slots.default}>
@@ -47,6 +50,6 @@
 		on:change
 		{value}
 		{...$$restProps}
-		class={inputClass(custom, color, false, tinted, $$slots.default || $$props.class)}
+		class={inputClass(custom, color, false, background, $$slots.default || $$props.class)}
 	/><slot />
 </Label>

--- a/src/lib/forms/SimpleSearch.svelte
+++ b/src/lib/forms/SimpleSearch.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
+
+	// tainted if put in component having its own background
+	let background: boolean = getContext('background');
+
 	export let id: string = '';
 	export let labelClass: string = 'sr-only';
 	export let iconClass: string = 'w-5 h-5 text-gray-500 dark:text-gray-400';
@@ -9,7 +14,6 @@
 	export let btnClass: string =
 		'p-2.5 ml-2 text-sm font-medium text-white bg-blue-700 rounded-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800';
 	export let placeholder: string = 'Search';
-	export let tinted: boolean = false;
 </script>
 
 <form class="flex items-center" on:submit>
@@ -32,7 +36,7 @@
 			{...$$restProps}
 			type="text"
 			{id}
-			class="{tinted
+			class="{background
 				? 'dark:bg-gray-600 dark:border-gray-500'
 				: ' dark:bg-gray-700 dark:border-gray-600'} {inputClass}"
 			{placeholder}

--- a/src/lib/forms/Toggle.svelte
+++ b/src/lib/forms/Toggle.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
 	import classNames from 'classnames';
 	import Checkbox from './Checkbox.svelte';
 	export let size: 'small' | 'default' | 'large' = 'default';
@@ -7,8 +8,11 @@
 	export let value: string = '';
 	export let checked: boolean = undefined;
 
+	// tinted if put in component having its own background
+	let background: boolean = getContext('background');
+
 	const common =
-		"mr-3 bg-gray-200 rounded-full peer-focus:ring-4 dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all dark:border-gray-600";
+		"mr-3 bg-gray-200 rounded-full peer-focus:ring-4 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all";
 
 	const colors = {
 		red: 'peer-focus:ring-red-300 dark:peer-focus:ring-red-800 peer-checked:bg-red-600',
@@ -25,9 +29,25 @@
 		default: 'w-11 h-6 after:top-0.5 after:left-[2px] after:h-5 after:w-5',
 		large: 'w-14 h-7 after:top-0.5 after:left-[4px]  after:h-6 after:w-6'
 	};
+
+	let divClass;
+	$: divClass = classNames(
+		common,
+		background ? 'dark:bg-gray-600 dark:border-gray-500' : 'dark:bg-gray-700 dark:border-gray-600',
+		colors[$$restProps.color ?? 'blue'],
+		sizes[size]
+	);
 </script>
 
-<Checkbox custom class="relative {$$props.class}" {value} bind:checked bind:group {...$$restProps} on:click>
-	<div class={classNames(common, colors[$$restProps.color ?? 'blue'], sizes[size])} />
+<Checkbox
+	custom
+	class="relative {$$props.class}"
+	{value}
+	bind:checked
+	bind:group
+	{...$$restProps}
+	on:click
+>
+	<div class={divClass} />
 	<slot />
 </Checkbox>

--- a/src/routes/dropdowns/index.md
+++ b/src/routes/dropdowns/index.md
@@ -157,13 +157,13 @@ Add multiple checkbox elements inside your dropdown menu to enable more advanced
 <ExampleDiv class="flex justify-center h-52">
   <Dropdown label="Dropdown checkbox" class="w-44">
     <DropdownItem>
-      <Checkbox tinted>Default checkbox</Checkbox>
+      <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
     <DropdownItem>
-      <Checkbox tinted checked>Checked state</Checkbox>
+      <Checkbox checked>Checked state</Checkbox>
     </DropdownItem>
     <DropdownItem>
-      <Checkbox tinted>Default checkbox</Checkbox>
+      <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
   </Dropdown>
 </ExampleDiv>
@@ -172,13 +172,13 @@ Add multiple checkbox elements inside your dropdown menu to enable more advanced
 ```html
 <Dropdown label="Dropdown checkbox" class="w-44">
   <DropdownItem>
-    <Checkbox tinted>Default checkbox</Checkbox>
+    <Checkbox>Default checkbox</Checkbox>
   </DropdownItem>
   <DropdownItem>
-    <Checkbox tinted checked>Checked state</Checkbox>
+    <Checkbox checked>Checked state</Checkbox>
   </DropdownItem>
   <DropdownItem>
-    <Checkbox tinted>Default checkbox</Checkbox>
+    <Checkbox>Default checkbox</Checkbox>
   </DropdownItem>
 </Dropdown>
 ```
@@ -192,13 +192,13 @@ Use this example to update the background color of a menu item when using a list
   <Dropdown label="Dropdown checkbox" class="w-48" >
     <ul slot="content" class="p-3 space-y-1">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Default checkbox</Checkbox>
+        <Checkbox>Default checkbox</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted checked>Checked state</Checkbox>
+        <Checkbox checked>Checked state</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Default checkbox</Checkbox>
+        <Checkbox>Default checkbox</Checkbox>
       </DropdownItem>
     </ul>
   </Dropdown>
@@ -209,13 +209,13 @@ Use this example to update the background color of a menu item when using a list
 <Dropdown label="Dropdown checkbox" class="w-48">
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Default checkbox</Checkbox>
+      <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted checked>Checked state</Checkbox>
+      <Checkbox checked>Checked state</Checkbox>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Default checkbox</Checkbox>
+      <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
   </ul>
 </Dropdown>
@@ -231,15 +231,15 @@ Add an extra helper text to each checkbox element inside the dropdown menu list 
   <Dropdown label="Dropdown checkbox" class="w-60" >
     <ul slot="content" class="p-3 space-y-1">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Enable notifications</Checkbox>
+        <Checkbox>Enable notifications</Checkbox>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted checked>Enable 2FA auth</Checkbox>
+        <Checkbox checked>Enable 2FA auth</Checkbox>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Subscribe newsletter</Checkbox>
+        <Checkbox>Subscribe newsletter</Checkbox>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
     </ul>
@@ -251,15 +251,15 @@ Add an extra helper text to each checkbox element inside the dropdown menu list 
 <Dropdown label="Dropdown checkbox" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Enable notifications</Checkbox>
+      <Checkbox>Enable notifications</Checkbox>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted checked>Enable 2FA auth</Checkbox>
+      <Checkbox checked>Enable 2FA auth</Checkbox>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Checkbox tinted>Subscribe newsletter</Checkbox>
+      <Checkbox>Subscribe newsletter</Checkbox>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
   </ul>
@@ -273,13 +273,13 @@ Add multiple radio elements inside your dropdown menu to enable more advanced in
 <ExampleDiv class="flex justify-center h-64">
   <Dropdown label="Dropdown radio" class="w-44">
     <DropdownItem>
-      <Radio bind:group={group1} value={1} tinted>Default radio</Radio>
+      <Radio bind:group={group1} value={1}>Default radio</Radio>
     </DropdownItem>
     <DropdownItem>
-      <Radio bind:group={group1} value={2} tinted>Checked state</Radio>
+      <Radio bind:group={group1} value={2}>Checked state</Radio>
     </DropdownItem>
     <DropdownItem>
-      <Radio bind:group={group1} value={3} tinted>Default radio</Radio>
+      <Radio bind:group={group1} value={3}>Default radio</Radio>
     </DropdownItem>
   </Dropdown>
 </ExampleDiv>
@@ -292,13 +292,13 @@ Add multiple radio elements inside your dropdown menu to enable more advanced in
 
 <Dropdown label="Dropdown radio" class="w-44">
     <DropdownItem>
-      <Radio bind:group={group1} value={1} tinted>Default radio</Radio>
+      <Radio bind:group={group1} value={1}>Default radio</Radio>
     </DropdownItem>
     <DropdownItem>
-      <Radio bind:group={group1} value={2} tinted>Checked state</Radio>
+      <Radio bind:group={group1} value={2}>Checked state</Radio>
     </DropdownItem>
     <DropdownItem>
-      <Radio bind:group={group1} value={3} tinted>Default radio</Radio>
+      <Radio bind:group={group1} value={3}>Default radio</Radio>
     </DropdownItem>
 </Dropdown>
 ```
@@ -312,13 +312,13 @@ Use this example to update the background color of a menu item when using a list
   <Dropdown label="Dropdown radio" class="w-48">
     <ul slot="content" class="p-3 space-y-1">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group2} value={1} tinted>Default radio</Radio>
+        <Radio bind:group={group2} value={1}>Default radio</Radio>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group2} value={2} tinted>Checked state</Radio>
+        <Radio bind:group={group2} value={2}>Checked state</Radio>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group2} value={3} tinted>Default radio</Radio>
+        <Radio bind:group={group2} value={3}>Default radio</Radio>
       </DropdownItem>
     </ul>
   </Dropdown>
@@ -333,13 +333,13 @@ Use this example to update the background color of a menu item when using a list
 <Dropdown label="Dropdown radio" class="w-48">
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group2} value={1} tinted>Default radio</Radio>
+      <Radio bind:group={group2} value={1}>Default radio</Radio>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group2} value={2} tinted>Checked state</Radio>
+      <Radio bind:group={group2} value={2}>Checked state</Radio>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group2} value={3} tinted>Default radio</Radio>
+      <Radio bind:group={group2} value={3}>Default radio</Radio>
     </DropdownItem>
   </ul>
 </Dropdown>
@@ -355,15 +355,15 @@ Add an extra helper text to each radio element inside the dropdown menu list wit
   <Dropdown label="Dropdown radio" class="w-60" >
     <ul slot="content" class="p-3 space-y-1">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group3} value={1} tinted>Enable notifications</Radio>
+        <Radio bind:group={group3} value={1}>Enable notifications</Radio>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group3} value={2} tinted>Enable 2FA auth</Radio>
+        <Radio bind:group={group3} value={2}>Enable 2FA auth</Radio>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Radio bind:group={group3} value={3} tinted>Subscribe newsletter</Radio>
+        <Radio bind:group={group3} value={3}>Subscribe newsletter</Radio>
         <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
     </ul>
@@ -375,15 +375,15 @@ Add an extra helper text to each radio element inside the dropdown menu list wit
 <Dropdown label="Dropdown radio" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={1} tinted>Enable notifications</Radio>
+      <Radio bind:group={group3} value={1}>Enable notifications</Radio>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={2} tinted>Enable 2FA auth</Radio>
+      <Radio bind:group={group3} value={2}>Enable 2FA auth</Radio>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
     <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-      <Radio bind:group={group3} value={3} tinted>Subscribe newsletter</Radio>
+      <Radio bind:group={group3} value={3}>Subscribe newsletter</Radio>
       <Helper class="pl-6 -mt-1">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
   </ul>
@@ -395,16 +395,16 @@ Add an extra helper text to each radio element inside the dropdown menu list wit
 Show a list of toggle switch elements inside the dropdown menu to enable a yes or no type of choice.
 
 <ExampleDiv class="flex justify-center h-64">
-  <Dropdown label="Dropdown radio" class="w-56">
+  <Dropdown label="Dropdown toggle" class="w-56">
   <ul slot="content" class="p-3 space-y-1">
     <DropdownItem class="rounded">
-      <Toggle checked>Default radio</Toggle>
+      <Toggle>Default toggle</Toggle>
     </DropdownItem>
     <DropdownItem class="rounded">
       <Toggle checked>Checked state</Toggle>
     </DropdownItem>
     <DropdownItem class="rounded">
-      <Toggle checked>Default radio</Toggle>
+      <Toggle>Default toggle</Toggle>
     </DropdownItem>
   </ul>
   </Dropdown>
@@ -414,13 +414,13 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 <Dropdown label="Dropdown radio" class="w-56">
 <ul slot="content" class="p-3 space-y-1">
   <DropdownItem class="rounded">
-    <Toggle checked>Default radio</Toggle>
+    <Toggle>Default radio</Toggle>
   </DropdownItem>
   <DropdownItem class="rounded">
     <Toggle checked>Checked state</Toggle>
   </DropdownItem>
   <DropdownItem class="rounded">
-    <Toggle checked>Default radio</Toggle>
+    <Toggle>Default radio</Toggle>
   </DropdownItem>
 </ul>
 </Dropdown>
@@ -560,26 +560,26 @@ Use this example if you want to add a search bar inside the dropdown menu to be 
 <Dropdown label="Project users" class="w-60">
   <svelte:fragment slot="content">
     <div class="p-3">
-      <SimpleSearch btnClass="hidden" tinted/>
+      <SimpleSearch btnClass="hidden"/>
     </div>
     <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Jese Leos</Checkbox>
+        <Checkbox>Jese Leos</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Robert Gouth</Checkbox>
+        <Checkbox>Robert Gouth</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted checked>Bonnie Green</Checkbox>
+        <Checkbox checked>Bonnie Green</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Jese Leos</Checkbox>
+        <Checkbox>Jese Leos</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Robert Gouth</Checkbox>
+        <Checkbox>Robert Gouth</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Bonnie Green</Checkbox>
+        <Checkbox>Bonnie Green</Checkbox>
       </DropdownItem>
     </ul>
     <a href="/" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">
@@ -593,26 +593,26 @@ Use this example if you want to add a search bar inside the dropdown menu to be 
 <Dropdown label="Project users" class="w-60">
   <svelte:fragment slot="content">
     <div class="p-3">
-      <SimpleSearch btnClass="hidden" tinted/>
+      <SimpleSearch btnClass="hidden"/>
     </div>
     <ul class="overflow-y-auto px-3 pb-3 space-y-1 h-48">
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Jese Leos</Checkbox>
+        <Checkbox>Jese Leos</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Robert Gouth</Checkbox>
+        <Checkbox>Robert Gouth</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted checked>Bonnie Green</Checkbox>
+        <Checkbox checked>Bonnie Green</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Jese Leos</Checkbox>
+        <Checkbox>Jese Leos</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Robert Gouth</Checkbox>
+        <Checkbox>Robert Gouth</Checkbox>
       </DropdownItem>
       <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
-        <Checkbox tinted>Bonnie Green</Checkbox>
+        <Checkbox>Bonnie Green</Checkbox>
       </DropdownItem>
     </ul>
     <a href="/" class="flex items-center p-3 text-sm font-medium text-red-600 bg-gray-50 border-t border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-red-500 hover:underline">


### PR DESCRIPTION
## 📑 Description
Form buttons again.

Found a way to get rid of `tinted` props. The slightly different dark rendering will be triggered by the parent component usage of `setContext('background',true)`. This is now added to `Dropdown` component.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit/version


## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
