### PR TITLE
fix: megamenu centered in small screen

### DIFF
--- a/src/lib/megamenu/MegaMenu.svelte
+++ b/src/lib/megamenu/MegaMenu.svelte
@@ -23,7 +23,7 @@
 	let ulClass: string;
 	$: ulClass = classNames(
 		'grid grid-flow-row gap-y-4 md:gap-x-0 auto-col-max auto-row-max',
-		full && $$slots.extra ? 'sm:grid-cols-2' : 'sm:grid-cols-2 md:grid-cols-3',
+		full && $$slots.extra ? 'grid-cols-2' : 'grid-cols-2 md:grid-cols-3',
 		'text-sm font-medium',
 		'text-gray-500 dark:text-gray-400',
 		full && $$slots.extra && 'md:w-2/3'

--- a/src/lib/navbar/NavDropdown.svelte
+++ b/src/lib/navbar/NavDropdown.svelte
@@ -2,7 +2,7 @@
 	import type { NavbarType } from '../types';
 	import { clickOutside } from '$lib/utils/clickOutside';
 
-	export let liButtonClass: string = 'flex items-center';
+	export let liButtonClass: string = 'flex items-center justify-between w-full';
 	export let name: string;
 	export let child: NavbarType[] = [];
 


### PR DESCRIPTION
## 📑 Description
Fix for mega menu centre problem.

https://github.com/themesberg/flowbite-svelte/pull/184#issuecomment-1197731636

In fact it was an issue of NavDropdown not MegaMenu.

I have modified the column number in small screen views as well. Please check if ok.


## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

If your branch is behind the upstream master, I may have difficulties to merge the request. Please fetch the latest version of the main branch:

```sh
git checkout your-branch
git pull upstream main
```

or

```sh
git checkout your-branch
git pull --rebase upstream main
```

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
