### PR TITLE
feat: focus trap for modals

### DIFF
--- a/src/lib/modals/Modal.svelte
+++ b/src/lib/modals/Modal.svelte
@@ -2,6 +2,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { setContext } from 'svelte';
 	import CloseButton from '$lib/utils/CloseButton.svelte';
+	import focusTrap from '$lib/utils/focusTrap';
 
 	export let open = false;
 	export let title: string = undefined;
@@ -24,15 +25,16 @@
 
 	let backdropEl: HTMLElement;
 
-	function init(node, _visible) {
+	function init(node, _open) {
 		getPlacementClasses().map((c) => node.classList.add(c));
-		if (_visible) createBackdrop(node);
+		_open && createBackdrop(node);
 
 		return {
-			update(_visible) {
+			update(_open) {
 				allPlacementClasses.map((c) => node.classList.remove(c));
 				getPlacementClasses().map((c) => node.classList.add(c));
-				_visible ? createBackdrop(node) : destroyBackdrop(node);
+
+				_open ? createBackdrop(node) : destroyBackdrop(node);
 			},
 
 			destroy() {
@@ -53,7 +55,8 @@
 			const body = document.querySelector('body');
 			body.append(backdropEl);
 			body.style.overflow = 'hidden';
-			body.addEventListener('keydown', handleEscape, true);
+
+			document.addEventListener('keydown', handleEscape, true);
 		}
 
 		dispatch('show', node);
@@ -62,10 +65,11 @@
 	function destroyBackdrop(node) {
 		const body = document.querySelector('body');
 		body.style.overflow = 'auto';
-		body.removeEventListener('keydown', handleEscape, true);
 
 		if (backdropEl) backdropEl.remove();
 		backdropEl = undefined;
+
+		document.removeEventListener('keydown', handleEscape, true);
 
 		dispatch('hide', node);
 	}
@@ -128,6 +132,7 @@
 	aria-modal={open ? 'true' : undefined}
 	role={open ? 'dialog' : undefined}
 	use:init={open}
+	use:focusTrap={open}
 	on:click={onButtonsClick}
 >
 	<div class="relative p-4 w-full {sizes[size]} h-full md:h-auto">

--- a/src/lib/utils/focusTrap.js
+++ b/src/lib/utils/focusTrap.js
@@ -1,0 +1,61 @@
+//
+// Focus trap copied from https://uxdesign.cc/how-to-trap-focus-inside-modal-to-make-it-ada-compliant-6a50f9a70700
+//
+
+// add all the elements inside modal which you want to make focusable
+const focusableElements =
+	'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function getFocusable(node) {
+	const focusableContent = node.querySelectorAll(focusableElements);
+	return [focusableContent[0], focusableContent[focusableContent.length - 1]];
+}
+
+export default function focusTrap(node, _open) {
+	let firstFocusableElement, lastFocusableElement; // first and last element to be focused inside modal
+
+	function handleFocusTrap(e) {
+		let isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+
+		if (!isTabPressed) {
+			return;
+		}
+
+		if (e.shiftKey) {
+			// if shift key pressed for shift + tab combination
+			if (document.activeElement === firstFocusableElement) {
+				lastFocusableElement.focus(); // add focus for the last focusable element
+				e.preventDefault();
+			}
+		} else {
+			// if tab key is pressed
+			if (document.activeElement === lastFocusableElement) {
+				// if focused has reached to last focusable element then focus first focusable element after pressing tab
+				firstFocusableElement.focus(); // add focus for the first focusable element
+				e.preventDefault();
+			}
+		}
+	}
+
+	if (_open) {
+		[firstFocusableElement, lastFocusableElement] = getFocusable(node);
+		document.addEventListener('keydown', handleFocusTrap, true);
+		firstFocusableElement.focus();
+	}
+
+	return {
+		update(_open) {
+			if (_open) {
+				[firstFocusableElement, lastFocusableElement] = getFocusable(node);
+				document.addEventListener('keydown', handleFocusTrap, true);
+				firstFocusableElement.focus();
+			} else {
+				document.removeEventListener('keydown', handleFocusTrap, true);
+			}
+		},
+
+		destroy() {
+			document.removeEventListener('keydown', handleFocusTrap, true);
+		}
+	};
+}


### PR DESCRIPTION
## 📑 Description
Focus trap for `Modal` component.
When modal is shown the focus moves only within the modal.

Implemented as shown here:  https://uxdesign.cc/how-to-trap-focus-inside-modal-to-make-it-ada-compliant-6a50f9a70700

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
