### PR TITLE
feat: alerts with lists

### DIFF
--- a/src/lib/alerts/Alert.svelte
+++ b/src/lib/alerts/Alert.svelte
@@ -63,7 +63,7 @@
 
 	let divClass: string;
 	$: divClass = classNames(
-		'flex flex-col p-4 mb-4 gap-2 ',
+		'flex flex-col p-4 mb-4 gap-2 text-sm',
 		bgClasses[color] ?? bgClasses.blue,
 		accent && (borderAccentClasses[color] ?? borderAccentClasses.blue),
 		rounded && 'rounded-lg ',
@@ -79,7 +79,7 @@
 			<svelte:component this={icon} class="flex-shrink-0 w-5 h-5 mr-3" />
 		{/if}
 
-		<div class="text-sm">
+		<div>
 			<slot />
 		</div>
 

--- a/src/routes/alerts/index.md
+++ b/src/routes/alerts/index.md
@@ -122,6 +122,52 @@ Import Alert and set variables in the script tag.
 </Alert>
 ```
 
+<Htwo label="Alerts with list" />
+
+Use this example to show a list and a description inside an alert component.
+
+<ExampleDiv>
+  <Alert icon={InformationCircle} class="bg-blue-50 text-blue-900">
+    <span class="sr-only">Info</span>
+    <span class="font-medium">Ensure that these requirements are met:</span>
+    <ul slot="extra" class="mt-0 ml-8 list-disc list-inside">
+      <li>At least 10 characters (and up to 100 characters)</li>
+      <li>At least one lowercase character</li>
+      <li>Inclusion of at least one special character, e.g., ! @ # ?</li>
+    </ul>
+  </Alert>
+  <Alert color="red" icon={InformationCircle} class="bg-red-50 text-red-900">
+    <span class="sr-only">Info</span>
+    <span class="font-medium">Ensure that these requirements are met:</span>
+    <ul slot="extra" class="mt-0 ml-8 list-disc list-inside">
+      <li>At least 10 characters (and up to 100 characters)</li>
+      <li>At least one lowercase character</li>
+      <li>Inclusion of at least one special character, e.g., ! @ # ?</li>
+    </ul>
+  </Alert>
+</ExampleDiv>
+
+```html
+<Alert icon={InformationCircle} class="bg-blue-50 text-blue-900">
+  <span class="sr-only">Info</span>
+  <span class="font-medium">Ensure that these requirements are met:</span>
+  <ul slot="extra" class="mt-0 ml-8 list-disc list-inside">
+    <li>At least 10 characters (and up to 100 characters)</li>
+    <li>At least one lowercase character</li>
+    <li>Inclusion of at least one special character, e.g., ! @ # ?</li>
+  </ul>
+</Alert>
+<Alert color="red" icon={InformationCircle} class="bg-red-50 text-red-900">
+  <span class="sr-only">Info</span>
+  <span class="font-medium">Ensure that these requirements are met:</span>
+  <ul slot="extra" class="mt-0 ml-8 list-disc list-inside">
+    <li>At least 10 characters (and up to 100 characters)</li>
+    <li>At least one lowercase character</li>
+    <li>Inclusion of at least one special character, e.g., ! @ # ?</li>
+  </ul>
+</Alert>
+```
+
 <Htwo label="Dismissable alerts" />
 
 <p>Use the following alert elements that are also dismissable.</p>


### PR DESCRIPTION
## 📑 Description
Alerts with list example added.

However **I don't understand** why Flowbite.com does not follow it's own coloring standard.
All alerts examples use the flowing colors:
`bg-blue-100 text-blue-700 dark:bg-blue-200 dark:text-blue-800`

and the newly added example introduces 
`bg-blue-50 text-blue-900`

**Why??** Setting color name on that alert has no sense at all.


## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
