### PR TITLE
fix: dropdown open/close api

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -13,6 +13,7 @@
 	export let labelClass: string =
 		'flex items-center justify-between w-full py-2 pl-3 pr-4 font-medium text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-gray-400 dark:hover:text-white dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent';
 	export let placement: 'auto' | Placement = 'bottom';
+	export let open: boolean = false;
 
 	setContext('background', true);
 
@@ -33,6 +34,7 @@
 	{placement}
 	arrow={tooltipArrow}
 	trigger="click"
+	bind:open
 >
 	<slot name="trigger">
 		{#if inline}

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -12,6 +12,7 @@
 	} from '@floating-ui/dom';
 	import type { Placement } from '@floating-ui/dom';
 	import { onDestroy } from 'svelte';
+	import { browser } from '$app/env';
 
 	export let placement: 'auto' | Placement = 'top';
 	export let trigger: 'hover' | 'click' = 'hover';
@@ -70,12 +71,14 @@
 	let attachedScroll: boolean = false;
 	$: tooltipRef && open && updatePosition();
 	$: {
-		if (open && !attachedScroll) {
-			attachedScroll = true;
-			window.addEventListener('scroll', updatePosition, true);
-		} else if (!open && attachedScroll) {
-			attachedScroll = false;
-			window.removeEventListener('scroll', updatePosition, true);
+		if (browser) {
+			if (open && !attachedScroll) {
+				attachedScroll = true;
+				window.addEventListener('scroll', updatePosition, true);
+			} else if (!open && attachedScroll) {
+				attachedScroll = false;
+				window.removeEventListener('scroll', updatePosition, true);
+			}
 		}
 	}
 	onDestroy(() => {

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -12,7 +12,6 @@
 	} from '@floating-ui/dom';
 	import type { Placement } from '@floating-ui/dom';
 	import { onDestroy } from 'svelte';
-	import { browser } from '$app/env';
 
 	export let placement: 'auto' | Placement = 'top';
 	export let trigger: 'hover' | 'click' = 'hover';
@@ -71,7 +70,7 @@
 	let attachedScroll: boolean = false;
 	$: tooltipRef && open && updatePosition();
 	$: {
-		if (browser) {
+		if (tooltipRef && triggerRef) {
 			if (open && !attachedScroll) {
 				attachedScroll = true;
 				window.addEventListener('scroll', updatePosition, true);

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -22,6 +22,7 @@
 	export let tipClass: string =
 		'absolute inline-block rounded-lg py-2 px-3 text-sm font-medium shadow-sm';
 	export let tipColor: string = '';
+	export let open = false;
 
 	const tipStyleClasses = {
 		dark: 'bg-gray-900 text-white dark:bg-gray-700',
@@ -45,7 +46,6 @@
 		tipStyleClasses[style],
 		$$props.class
 	);
-	let open = false;
 	const floatingPlacement = (placement: 'auto' | Placement): Placement | undefined => {
 		return placement === 'auto' ? undefined : placement;
 	};
@@ -63,7 +63,7 @@
 	let placementData: ComputePositionReturn;
 	let tooltipRef: HTMLElement, triggerRef: HTMLElement, arrowRef: HTMLElement;
 	const updatePosition = () =>
-		computePosition(triggerRef as Element, tooltipRef as Element, {
+		computePosition(triggerRef as Element, tooltipRef as HTMLElement, {
 			middleware: floatingMiddleware(arrowRef, placement),
 			placement: floatingPlacement(placement)
 		}).then((data) => (placementData = data));

--- a/src/routes/dropdowns/index.md
+++ b/src/routes/dropdowns/index.md
@@ -32,6 +32,8 @@ layout: dropdownLayout
   const handleClick = ()=>{
     alert ('Clicked.')
   }
+
+  let dropdownOpen = false;
 </script>
 
 <Breadcrumb>
@@ -173,6 +175,26 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
   <DropdownItem>Sign out</DropdownItem>
 </Dropdown>
 ```
+
+<Htwo label="Programatic open/close" />
+
+When you want to control your dropdown open status via javascript code you can bind to `open` property.
+
+<ExampleDiv class="flex justify-center h-64">
+<Dropdown label="Dropdown button" class="w-44" bind:open={dropdownOpen}>
+  <DropdownItem on:click={() => dropdownOpen = false}>Dashboard (close)</DropdownItem>
+  <DropdownItem>
+    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-10 md:ml-16 w-44">
+    <DropdownItem on:click={() => dropdownOpen = false}>Overview (close)</DropdownItem>
+    <DropdownItem>My downloads</DropdownItem>
+    <DropdownItem>Billing</DropdownItem>
+    </Dropdown>
+  </DropdownItem>
+  <DropdownItem>Earnings</DropdownItem>
+  <DropdownDivider />
+  <DropdownItem>Sign out</DropdownItem>
+</Dropdown>
+</ExampleDiv>
 
 <Htwo label="Dropdown with checkbox" />
 

--- a/src/routes/dropdowns/index.md
+++ b/src/routes/dropdowns/index.md
@@ -196,6 +196,22 @@ When you want to control your dropdown open status via javascript code you can b
 </Dropdown>
 </ExampleDiv>
 
+```html
+<Dropdown label="Dropdown button" class="w-44" bind:open={dropdownOpen}>
+  <DropdownItem on:click={() => dropdownOpen = false}>Dashboard (close)</DropdownItem>
+  <DropdownItem>
+    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-10 md:ml-16 w-44">
+    <DropdownItem on:click={() => dropdownOpen = false}>Overview (close)</DropdownItem>
+    <DropdownItem>My downloads</DropdownItem>
+    <DropdownItem>Billing</DropdownItem>
+    </Dropdown>
+  </DropdownItem>
+  <DropdownItem>Earnings</DropdownItem>
+  <DropdownDivider />
+  <DropdownItem>Sign out</DropdownItem>
+</Dropdown>
+```
+
 <Htwo label="Dropdown with checkbox" />
 
 Add multiple checkbox elements inside your dropdown menu to enable more advanced input interaction.


### PR DESCRIPTION
## 📑 Description
Closes #217 

- `Tooltip` variable `open` changed to be exported
- `Dropdown` - export `open` variable bind to `Tooltip`
- doc added example how to control dropdown via `open` var

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
