### PR TITLE
Fix CLS in DropDown / Popper

### DIFF
--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -74,7 +74,7 @@
 	$: divClass = classNames(
 		'z-10',
 		animation && `transition-opacity ${animation}`,
-		open ? 'visible opacity-100' : 'invisible opacity-0',
+		open ? 'visible opacity-100' : 'absolute invisible opacity-0',
 		$$props.class
 	);
 </script>

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -74,7 +74,7 @@
 	$: divClass = classNames(
 		'z-10',
 		animation && `transition-opacity ${animation}`,
-		open ? 'visible opacity-100' : 'absolute invisible opacity-0',
+		open ? 'visible opacity-100' : 'invisible opacity-0',
 		$$props.class
 	);
 </script>
@@ -99,6 +99,7 @@
 	on:focusout={activeContent ? hideHandler : undefined}
 	on:mouseenter={activeContent && !clickable ? showHandler : undefined}
 	on:mouseleave={activeContent && !clickable ? hideHandler : undefined}
+	style="position: absolute;"
 >
 	<slot />
 	{#if arrow}<div data-popper-arrow />{/if}


### PR DESCRIPTION
Closes #245 

## 📑 Description
Just using visible as a class does not remove the space it needs from the dom. Well, it somehow does for some reason, but not before half a second or so, which causes half a second of CLS.
Using "hidden" removes it from the dom, but breaks the animation.
Solution: use "absolute". Keeps the animation & removed the space from the dom => no CLS anymore.

This is a simple fix, but I'd still be interested to know why that space from the dom is removed after like half-a-second? Is it adding some kind of hidden element after a delay or so to keep the animation? Because if so, that could be removed