### PR TITLE
Prevent DropdownItem to force full page-refresh if it contains a link

### DIFF
--- a/src/lib/dropdowns/DropdownItem.svelte
+++ b/src/lib/dropdowns/DropdownItem.svelte
@@ -13,7 +13,7 @@
 <li
 	{...$$restProps}
 	class={classNames(liClass, colors[color] ?? colors.default, $$props.class)}
-	on:click|stopPropagation
+	on:click
 	on:change
 	on:keydown
 	on:keyup


### PR DESCRIPTION
Fixes #244 . I don't know the reason why `|stopPropagation` is necessary, but it breaks client-side navigation if there is a link inside the DropdownItem.