### PR TITLE
feat: toolbar

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -181,6 +181,11 @@ export { default as TimelineItemVertical } from './timelines/TimelineItemVertica
 // Toast
 export { default as Toast } from './toasts/Toast.svelte';
 
+// Toolbar
+export { default as Toolbar } from './toolbar/Toolbar.svelte';
+export { default as ToolbarButton } from './toolbar/ToolbarButton.svelte';
+export { default as ToolbarGroup } from './toolbar/ToolbarGroup.svelte';
+
 // Tooltips
 export { default as Tooltip } from './tooltips/Tooltip.svelte';
 

--- a/src/lib/toolbar/Toolbar.svelte
+++ b/src/lib/toolbar/Toolbar.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import classNames from 'classnames';
+
+	const separators = writable(false);
+	setContext('toolbar', separators);
+
+	export let color: string = 'dark';
+	export let embedded: boolean = false;
+
+	const bgColors = {
+		gray: 'bg-gray-100 dark:bg-gray-200 ',
+		red: 'bg-red-100 dark:bg-red-200',
+		yellow: 'bg-yellow-100 dark:bg-yellow-200 ',
+		green: 'bg-green-100 dark:bg-green-200 ',
+		indigo: 'bg-indigo-100 dark:bg-indigo-200 ',
+		purple: 'bg-purple-100 dark:bg-purple-200 ',
+		pink: 'bg-pink-100 dark:bg-pink-200 ',
+		blue: 'bg-blue-100 dark:bg-blue-200 ',
+		dark: 'bg-gray-50 dark:bg-gray-700'
+		// custom: customBgClass
+	};
+
+	const textColors = {
+		gray: 'text-gray-500 dark:text-gray-700',
+		red: 'text-red-500 dark:text-red-700',
+		yellow: 'text-yellow-500 dark:text-yellow-700',
+		green: 'text-green-500 dark:text-green-700',
+		indigo: 'text-indigo-500 dark:text-indigo-700',
+		purple: 'text-purple-500 dark:text-purple-700',
+		pink: 'text-pink-500 dark:text-pink-700',
+		blue: 'text-blue-500 dark:text-blue-700',
+		dark: 'text-gray-500 dark:text-gray-400'
+		// custom: customTextColor
+	};
+
+	let divClass;
+	$: divClass = classNames(
+		'flex justify-between items-center',
+		embedded || 'rounded-lg border border-gray-200 dark:border-gray-600 py-2 px-3',
+		embedded || textColors[color],
+		embedded || bgColors[color],
+		$$props.class
+	);
+
+	const divideColors = {
+		gray: 'divide-gray-200 dark:divide-gray-700',
+		red: 'divide-red-200 dark:divide-red-700',
+		yellow: 'divide-yellow-200 dark:divide-yellow-700',
+		green: 'divide-green-200 dark:divide-green-700',
+		indigo: 'divide-indigo-200 dark:divide-indigo-700',
+		purple: 'divide-purple-200 dark:divide-purple-700',
+		pink: 'divide-pink-200 dark:divide-pink-700',
+		blue: 'divide-blue-200 dark:divide-blue-700',
+		dark: 'divide-gray-200 dark:divide-gray-600'
+		// custom: customTextColor
+	};
+
+	let separatorsClass;
+	$: separatorsClass = classNames(
+		$separators && 'divide-gray-200 sm:divide-x',
+		//  dark:divide-gray-600'
+		divideColors[color]
+	);
+</script>
+
+<div class={divClass}>
+	<div class="flex flex-wrap items-center {separatorsClass}">
+		<slot />
+	</div>
+	<slot name="end" />
+</div>

--- a/src/lib/toolbar/ToolbarButton.svelte
+++ b/src/lib/toolbar/ToolbarButton.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import classNames from 'classnames';
+
+	const background = getContext('background');
+
+	export let color: string = 'default';
+	export let name: string = undefined;
+	export let ariaLabel: string = undefined;
+	export let size: 'xs' | 'sm' | 'md' = 'md';
+
+	const colors = {
+		default:
+			'hover:text-gray-900 hover:bg-gray-100 text-gray-500 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600',
+		gray: 'focus:ring-gray-400 hover:bg-gray-200 dark:hover:bg-gray-300',
+		red: 'focus:ring-red-400 hover:bg-red-200 dark:hover:bg-red-300',
+		yellow: 'focus:ring-yellow-400 hover:bg-yellow-200 dark:hover:bg-yellow-300',
+		green: 'focus:ring-green-400 hover:bg-green-200 dark:hover:bg-green-300',
+		indigo: 'focus:ring-indigo-400 hover:bg-indigo-200 dark:hover:bg-indigo-300',
+		purple: 'focus:ring-purple-400 hover:bg-purple-200 dark:hover:bg-purple-300',
+		pink: 'focus:ring-pink-400 hover:bg-pink-200 dark:hover:bg-pink-300',
+		blue: 'focus:ring-blue-400 hover:bg-blue-200 dark:hover:bg-blue-300'
+	};
+
+	const sizing = {
+		xs: 'm-0.5 rounded focus:ring-1 p-0.5',
+		sm: 'm-0.5 rounded focus:ring-1 p-0.5',
+		md: 'rounded-lg focus:ring-2 p-1.5'
+	};
+
+	let buttonClass: string;
+	$: buttonClass = classNames(
+		'focus:outline-none whitespace-normal',
+		sizing[size],
+		colors[color],
+		color === 'default' &&
+			(background
+				? 'hover:bg-gray-100 dark:hover:bg-gray-600'
+				: 'hover:bg-gray-100 dark:hover:bg-gray-700'),
+		$$props.class
+	);
+
+	const svgSizes = {
+		xs: 'w-3 h-3',
+		sm: 'w-3.5 h-3.5',
+		md: 'w-5 h-5'
+	};
+</script>
+
+<button on:click type="button" class={buttonClass} aria-label={ariaLabel ?? name}>
+	{#if name}<span class="sr-only">{name}</span>{/if}
+	<slot>
+		<svg
+			class={svgSizes[size]}
+			fill="currentColor"
+			viewBox="0 0 20 20"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fill-rule="evenodd"
+				d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	</slot>
+</button>

--- a/src/lib/toolbar/ToolbarGroup.svelte
+++ b/src/lib/toolbar/ToolbarGroup.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { Writable } from 'svelte/store';
+	import { getContext } from 'svelte';
+
+	const options: Writable<boolean> = getContext('toolbar');
+	if (options) $options = true;
+</script>
+
+<div class="flex items-center space-x-1 sm:pr-4 sm:pl-4 first:sm:pl-0 last:sm:pr-0">
+	<slot />
+</div>

--- a/src/routes/props/Toolbar.json
+++ b/src/routes/props/Toolbar.json
@@ -1,0 +1,1 @@
+{"props":[["color","string ","'dark'"],["embedded","boolean ","false"]]}

--- a/src/routes/props/ToolbarButton.json
+++ b/src/routes/props/ToolbarButton.json
@@ -1,0 +1,1 @@
+{"props":[["color","string ","'default'"],["name","string ","undefined"],["ariaLabel","string ","undefined"],["size","'xs' | 'sm' | 'md' ","'md'"]]}

--- a/src/routes/toolbar/+page.md
+++ b/src/routes/toolbar/+page.md
@@ -1,0 +1,141 @@
+---
+layout: tooltipLayout
+---
+
+<script>
+  import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
+  import { Toolbar, ToolbarButton, ToolbarGroup, Avatar, Button, Textarea, Breadcrumb, BreadcrumbItem, PaperAirplane, PaperClip, Photo, MapPin, CodeBracket, FaceSmile } from '$lib'
+  import { Home, Mail, QuestionMarkCircle, Qrcode } from 'svelte-heros'
+  
+  import componentProps from '../props/Toolbar.json'
+  // Props table
+  let items = componentProps.props
+  let propHeader = ['Name', 'Type', 'Default']
+
+  let divClass='w-full relative overflow-x-auto shadow-md sm:rounded-lg py-4'
+  let theadClass ='text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-white'
+</script>
+
+<Breadcrumb>
+  <BreadcrumbItem href="/" icon={Home} variation="solid">Home</BreadcrumbItem>
+  <BreadcrumbItem>Toolbar</BreadcrumbItem>
+</Breadcrumb>
+
+<h1 class="text-3xl w-full dark:text-white pt-8 pb-4">Tooltips</h1>
+
+<CompoDescription>Use the following Tailwind CSS powered toolbars to show groups of tool buttons</CompoDescription>
+
+<ExampleDiv>
+<GitHubSource href="tooltips/Tooltip.svelte">Tooltip</GitHubSource>
+</ExampleDiv>
+
+
+
+<Htwo label="Setup" />
+
+```html
+<script>
+	import { Toolbar, ToolbarButton, ToolbarGroup } from 'flowbite-svelte';
+</script>
+```
+
+<Htwo label="Default toolbar" />
+
+<ExampleDiv>
+<Toolbar>
+	<ToolbarButton><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+</ExampleDiv>
+
+<Htwo label="Colored toolbars" />
+
+<ExampleDiv class="space-y-4">
+<Toolbar color="red">
+	<ToolbarButton color="red"><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton color="red"><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton color="red"><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end" color="red"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+<Toolbar color="blue">
+	<ToolbarButton color="blue"><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton color="blue"><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton color="blue"><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end" color="blue"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+</ExampleDiv>
+
+<Htwo label="Toolbar with groups" />
+
+<ExampleDiv>
+<Toolbar color="green">
+    <ToolbarGroup>
+        <ToolbarButton color="green"><Home variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Qrcode variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Mail variation="solid" /></ToolbarButton>
+    </ToolbarGroup>
+    <ToolbarGroup>
+        <ToolbarButton color="green"><Home variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Qrcode variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Mail variation="solid" /></ToolbarButton>
+    </ToolbarGroup>
+    <ToolbarButton slot="end" color="green"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+</ExampleDiv>
+
+<Htwo label="WYSIWYG Editor" />
+
+If you want to add other actions as buttons alongside your textarea component, such as with a WYSIWYG editor, then you can use the example below.
+
+<ExampleDiv>
+<form>
+  <label for="editor" class="sr-only">Publish post</label>
+  <Textarea id="editor" rows="8" class="mb-4" placeholder="Write a comment">
+    <Toolbar slot="header" embedded>
+      <ToolbarGroup>
+        <ToolbarButton name="Attach file"><PaperClip size={20} variation="solid"/></ToolbarButton>
+        <ToolbarButton name="Embed map"><MapPin size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Upload image"><Photo size={20} variation="solid" /></ToolbarButton>
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <ToolbarButton name="Format code"><CodeBracket size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Add emoji"><FaceSmile size={20} variation="solid" /></ToolbarButton>
+      </ToolbarGroup>
+      <ToolbarButton name="send" slot="end"><PaperAirplane size={20} variation="solid" /></ToolbarButton>
+    </Toolbar>
+  </Textarea>
+  <Button>Publish post</Button>
+</form>
+</ExampleDiv>
+
+<Htwo label="Comment box" />
+
+Most often the textarea component is used as the main text field input element in comment sections. Use this example to also apply a helper text and buttons below the textarea itself.
+
+<ExampleDiv class="space-y-4">
+<form>
+  <Textarea class="mb-4" placeholder="Write a comment">
+    <div slot="footer" class="flex items-center justify-between">
+    <Button type="submit">Post comment</Button>
+    <Toolbar embedded>
+        <ToolbarButton name="Attach file"><PaperClip size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Set location"><MapPin size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Upload image"><Photo size={20} variation="solid" /></ToolbarButton>
+    </Toolbar>
+    </div>
+  </Textarea>
+</form>
+<p class="ml-auto text-xs text-gray-500 dark:text-gray-400">Remember, contributions to this topic should follow our <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">Community Guidelines</a>.</p>
+
+</ExampleDiv>
+
+<Htwo label="Props" />
+
+<p>The component has the following props, type, and default values. See <a href="/pages/types">types 
+ page</a> for type information.</p>
+
+<TableProp header={propHeader} {divClass} {theadClass}>
+  <TableDefaultRow {items} rowState='hover' />
+</TableProp>

--- a/src/routes/toolbar/+page.md
+++ b/src/routes/toolbar/+page.md
@@ -50,6 +50,15 @@ layout: tooltipLayout
 </Toolbar>
 </ExampleDiv>
 
+```html
+<Toolbar>
+	<ToolbarButton><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+```
+
 <Htwo label="Colored toolbars" />
 
 <ExampleDiv class="space-y-4">
@@ -66,6 +75,22 @@ layout: tooltipLayout
     <ToolbarButton slot="end" color="blue"><Home variation="solid"/></ToolbarButton>
 </Toolbar>
 </ExampleDiv>
+
+```html
+<Toolbar color="red">
+	<ToolbarButton color="red"><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton color="red"><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton color="red"><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end" color="red"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+
+<Toolbar color="blue">
+	<ToolbarButton color="blue"><Home variation="solid"/></ToolbarButton>
+	<ToolbarButton color="blue"><Qrcode variation="solid"/></ToolbarButton>
+    <ToolbarButton color="blue"><Mail variation="solid" /></ToolbarButton>
+    <ToolbarButton slot="end" color="blue"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+```
 
 <Htwo label="Toolbar with groups" />
 
@@ -84,6 +109,22 @@ layout: tooltipLayout
     <ToolbarButton slot="end" color="green"><Home variation="solid"/></ToolbarButton>
 </Toolbar>
 </ExampleDiv>
+
+```html
+<Toolbar color="green">
+    <ToolbarGroup>
+        <ToolbarButton color="green"><Home variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Qrcode variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Mail variation="solid" /></ToolbarButton>
+    </ToolbarGroup>
+    <ToolbarGroup>
+        <ToolbarButton color="green"><Home variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Qrcode variation="solid"/></ToolbarButton>
+        <ToolbarButton color="green"><Mail variation="solid" /></ToolbarButton>
+    </ToolbarGroup>
+    <ToolbarButton slot="end" color="green"><Home variation="solid"/></ToolbarButton>
+</Toolbar>
+```
 
 <Htwo label="WYSIWYG Editor" />
 
@@ -110,6 +151,26 @@ If you want to add other actions as buttons alongside your textarea component, s
 </form>
 </ExampleDiv>
 
+```html
+<form>
+  <label for="editor" class="sr-only">Publish post</label>
+  <Textarea id="editor" rows="8" class="mb-4" placeholder="Write a comment">
+    <Toolbar slot="header" embedded>
+      <ToolbarGroup>
+        <ToolbarButton name="Attach file"><PaperClip size={20} variation="solid"/></ToolbarButton>
+        <ToolbarButton name="Embed map"><MapPin size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Upload image"><Photo size={20} variation="solid" /></ToolbarButton>
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <ToolbarButton name="Format code"><CodeBracket size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Add emoji"><FaceSmile size={20} variation="solid" /></ToolbarButton>
+      </ToolbarGroup>
+      <ToolbarButton name="send" slot="end"><PaperAirplane size={20} variation="solid" /></ToolbarButton>
+    </Toolbar>
+  </Textarea>
+  <Button>Publish post</Button>
+</form>
+```
 <Htwo label="Comment box" />
 
 Most often the textarea component is used as the main text field input element in comment sections. Use this example to also apply a helper text and buttons below the textarea itself.
@@ -128,8 +189,23 @@ Most often the textarea component is used as the main text field input element i
   </Textarea>
 </form>
 <p class="ml-auto text-xs text-gray-500 dark:text-gray-400">Remember, contributions to this topic should follow our <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">Community Guidelines</a>.</p>
-
 </ExampleDiv>
+
+```html
+<form>
+  <Textarea class="mb-4" placeholder="Write a comment">
+    <div slot="footer" class="flex items-center justify-between">
+    <Button type="submit">Post comment</Button>
+    <Toolbar embedded>
+        <ToolbarButton name="Attach file"><PaperClip size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Set location"><MapPin size={20} variation="solid" /></ToolbarButton>
+        <ToolbarButton name="Upload image"><Photo size={20} variation="solid" /></ToolbarButton>
+    </Toolbar>
+    </div>
+  </Textarea>
+</form>
+<p class="ml-auto text-xs text-gray-500 dark:text-gray-400">Remember, contributions to this topic should follow our <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">Community Guidelines</a>.</p>
+```
 
 <Htwo label="Props" />
 


### PR DESCRIPTION
## 📑 Description

Components:
- `Toolbar` - not part of the Flowbite.com but presented in `Textarea` examples.
- `ToolbarButton` - button designed to but put on the toolbar, but we can migrate `CloseButton` to be a specific `ToolbarButton`
- `ToolbarGroup` - for groupping many `ToolbarButton`

In docs, I have re-used the modified `Textarea` examples here to demonstrate the simplified implementation.
Should we add that to the framework?

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
Only `lib/toolbar/*.svelte` and `routes/toolbar/+page.md`  added. To see the docs you need to manually navigate to `/toolbar`
