### PR TITLE
Popper again

### DIFF
--- a/src/lib/avatar/Avatar.svelte
+++ b/src/lib/avatar/Avatar.svelte
@@ -37,17 +37,17 @@
 
 <Dot show={$$props.dot} {rounded} {...dot} {size} class={sizes[size]}>
 	{#if src}
-		<img class={avatarClass} {alt} {src} />
+		<img {alt} {src} {...$$restProps} class={avatarClass} />
 	{:else if $$slots.default}
 		<svelte:element
 			this={href ? 'a' : 'div'}
-			class="flex justify-center items-center text-xs font-medium {avatarClass}"
 			{href}
-		>
+			{...$$restProps}
+			class="flex justify-center items-center text-xs font-medium {avatarClass}">
 			<slot />
 		</svelte:element>
 	{:else}
-		<svelte:element this={href ? 'a' : 'div'} class={avatarClass}>
+		<svelte:element this={href ? 'a' : 'div'} {...$$restProps} class={avatarClass}>
 			<AvatarPlaceholder {rounded} />
 		</svelte:element>
 	{/if}

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -7,6 +7,7 @@
 	import ChevronRight from '../utils/ChevronRight.svelte';
 	import ChevronDown from '../utils/ChevronDown.svelte';
 	import ChevronLeft from '../utils/ChevronLeft.svelte';
+	import generateId from '$lib/utils/generateId';
 	import type { Placement } from '@popperjs/core';
 
 	export let label: string = '';
@@ -16,6 +17,9 @@
 		'flex items-center justify-between w-full py-2 pl-3 pr-4 font-medium text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-gray-400 dark:hover:text-white dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent';
 	export let placement: 'auto' | Placement = 'bottom';
 	export let open: boolean = false;
+	export let triggers: string = undefined;
+
+	let id = generateId();
 
 	setContext('background', true);
 
@@ -39,18 +43,10 @@
 	);
 </script>
 
-<Popper
-	activeContent={true}
-	arrow={false}
-	{placement}
-	{...$$restProps}
-	class={popoverClass}
-	trigger="click"
-	on:show
-	bind:open>
-	<slot name="trigger" slot="trigger">
+{#if label}
+	<slot name="trigger">
 		{#if inline}
-			<button class={labelClass} class:flex-row-reverse={icon == ChevronLeft}>
+			<button {id} class={labelClass} class:flex-row-reverse={icon == ChevronLeft}>
 				<slot name="label">{label}</slot>
 				{#if arrowIcon}
 					<svelte:component
@@ -59,7 +55,7 @@
 				{/if}
 			</button>
 		{:else}
-			<Button {...$$restProps} class={icon == ChevronLeft && 'flex-row-reverse'}>
+			<Button {id} {...$$restProps} class={icon == ChevronLeft && 'flex-row-reverse'}>
 				<slot name="label">{label}</slot>
 				{#if arrowIcon}
 					<svelte:component
@@ -69,6 +65,18 @@
 			</Button>
 		{/if}
 	</slot>
+{/if}
+
+<Popper
+	activeContent={true}
+	arrow={false}
+	{placement}
+	{...$$restProps}
+	class={popoverClass}
+	trigger="click"
+	on:show
+	bind:open
+	triggers={triggers ?? '#' + id}>
 	<slot name="content">
 		<ul class="py-1">
 			<slot />

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -17,7 +17,7 @@
 		'flex items-center justify-between w-full py-2 pl-3 pr-4 font-medium text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-gray-400 dark:hover:text-white dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent';
 	export let placement: 'auto' | Placement = 'bottom';
 	export let open: boolean = false;
-	export let triggers: string = undefined;
+	export let triggeredBy: string = undefined;
 
 	let id = generateId();
 
@@ -76,7 +76,7 @@
 	trigger="click"
 	on:show
 	bind:open
-	triggers={triggers ?? '#' + id}>
+	triggeredBy={triggeredBy ?? '#' + id}>
 	<slot name="content">
 		<ul class="py-1">
 			<slot />

--- a/src/lib/dropdowns/DropdownItem.svelte
+++ b/src/lib/dropdowns/DropdownItem.svelte
@@ -21,6 +21,7 @@
 	on:blur
 	on:mouseenter
 	on:mouseleave
+	tabindex="0"
 >
 	<slot />
 </li>

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -3,6 +3,7 @@
 	import classNames from 'classnames';
 
 	export let title: string = '';
+	export let triggeredBy: string;
 
 	let popoverClass: string;
 	$: popoverClass = classNames(
@@ -14,12 +15,11 @@
 	);
 </script>
 
-<Popper activeContent={true} {...$$restProps} class={popoverClass} on:show>
+<Popper activeContent={true} {triggeredBy} {...$$restProps} class={popoverClass} on:show>
 	<slot name="trigger" slot="trigger" />
 	{#if $$slots.title || title}
 		<div
-			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700"
-		>
+			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
 			<slot name="title">
 				<h3 class="font-semibold text-gray-900 dark:text-white">{title}</h3>
 			</slot>

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Popper from '$lib/utils/Popper.svelte';
 	import classNames from 'classnames';
+	import generateId from '$lib/utils/generateId';
 
 	export let content: string = '';
 	export let style: 'dark' | 'light' | 'auto' | 'custom' = 'dark';
@@ -8,6 +9,8 @@
 	export let tipColor: string = '';
 
 	export let tipClass: string = 'py-2 px-3 text-sm font-medium rounded-lg shadow-sm tooltip';
+
+	export let triggeredBy: string;
 
 	const tipStyleClasses = {
 		dark: 'border border-gray-800 bg-gray-900 text-white dark:bg-gray-700 dark:border-gray-600',
@@ -18,9 +21,18 @@
 
 	let toolTipClass;
 	$: toolTipClass = classNames(tipClass, tipStyleClasses[style], $$props.class);
+
+	let id = generateId();
 </script>
 
-<Popper activeContent={false} {...$$restProps} class={toolTipClass} on:show>
-	<slot slot="trigger" />
+<div {id}>
+	<slot />
+</div>
+<Popper
+	activeContent={false}
+	triggeredBy={triggeredBy ?? '#' + id}
+	{...$$restProps}
+	class={toolTipClass}
+	on:show>
 	<slot name="content">{content}</slot>
 </Popper>

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -1,54 +1,83 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import { createPopper } from '@popperjs/core';
 	import classNames from 'classnames';
 
-	import type { Modifier, Placement, Instance } from '@popperjs/core';
+	import type { Modifier, Placement, Instance, VirtualElement } from '@popperjs/core';
 
 	const dispatch = createEventDispatcher();
 
+	export let triggers: string;
 	export let open: boolean = false;
 
 	export let placement: Placement = 'top';
 	export let offset: number = 8;
 	export let trigger: 'hover' | 'click' = 'hover';
 	export let arrow: boolean = true;
-	export let animation: false | `duration-${number}` = 'duration-300';
-
+	// export let animation: false | `duration-${number}` = 'duration-3000';
 	export let activeContent: boolean;
 
 	let clickable: boolean;
 	$: clickable = trigger === 'click';
 
-	let triggerEl, contentEl, popper: Instance;
+	let triggerEl;
+	let triggerEls = [];
+	let popper: Instance;
 
 	let _blocked: boolean = false; // managment of the race condition between focusin and click events
-	const block = () => ((_blocked = true), setTimeout(() => (_blocked = false), 500));
+	const block = () => ((_blocked = true), setTimeout(() => (_blocked = false), 250));
 
-	const showHandler = (ev) => {
+	$: console.log(triggers, document.querySelectorAll(triggers));
+
+	const showHandler = (ev: Event) => {
+		console.log('show', ev.type, ev.target);
+		if (triggerEl === undefined) triggerEl = ev.target;
+		else if (triggerEls.includes(ev.target) && triggerEl !== ev.target) {
+			popper.state.elements.reference = ev.target as HTMLElement;
+			popper.setOptions({ placement });
+			triggerEl = ev.target;
+			block();
+		}
 		if (clickable && ev.type === 'focusin' && !open) block();
-		open = ev.type === 'click' && !_blocked ? !open : true;
+		open = clickable && ev.type === 'click' && !_blocked ? !open : true;
 	};
+
+	// typescript typeguards - poper.state.element.reference: Element|HTMLElement|VirtualElement
+	const hasHover = (x) => (x as Element).matches && (x as Element).matches(':hasHover');
+	const hasFocus = (x) =>
+		(x as Element).contains && (x as Element).contains(document.activeElement);
 
 	const hideHandler = (ev) => {
-		if (activeContent)
-			setTimeout(
-				() =>
-					(!clickable && (triggerEl.matches(':hover') || contentEl.matches(':hover'))) ||
-					contentEl.contains(document.activeElement) ||
-					(open = false),
-				100
-			);
-		else open = false;
+		if (!_blocked)
+			setTimeout(() => {
+				const elements = Object.values(popper.state.elements);
+				if (ev.type === 'mouseleave' && elements.some(hasHover)) return;
+				if (ev.type === 'focusout' && elements.some(hasFocus)) return;
+				open = false;
+			}, 100);
 	};
 
-	$: {
-		if (triggerEl && contentEl) {
-			popper = createPopper(triggerEl, contentEl, {
-				placement,
-				modifiers: [{ name: 'offset', options: { offset: [0, offset] } }]
-			});
-		}
+	function init(node, _open) {
+		console.log('init', triggers, triggerEl);
+		// const popper: Instance = createPopper(triggerEl, node, {
+		popper = createPopper(triggerEl, node, {
+			placement,
+			modifiers: [
+				{ name: 'offset', options: { offset: [0, offset] } },
+				{ name: 'eventListeners', enabled: open }
+			]
+		});
+		return {
+			update(_open) {
+				console.log('update');
+				updatePopper(popper);
+			},
+			destroy() {
+				console.log('destroy');
+				popper.destroy();
+			}
+		};
 	}
 
 	function enableListeners(modifiers: Modifier<any, any>[]) {
@@ -58,49 +87,62 @@
 		return modifiers;
 	}
 
-	$: {
-		if (popper) {
-			// Enable the event listeners
-			popper.setOptions(({ modifiers, ...options }) => ({
-				...options,
-				modifiers: enableListeners(modifiers)
-			}));
-			open && popper.update(); // Update the position
-			dispatch('show', open);
-		}
+	function updatePopper(popper: Instance) {
+		// Enable the event listeners
+		popper.setOptions(({ modifiers, ...options }) => ({
+			...options,
+			modifiers: enableListeners(modifiers)
+		}));
+		open && popper.update(); // Update the position
+		dispatch('show', open);
 	}
 
 	let divClass: string;
-	$: divClass = classNames(
-		'z-10',
-		animation && `transition-opacity ${animation}`,
-		open ? 'visible opacity-100' : 'invisible opacity-0',
-		$$props.class
-	);
+	$: divClass = classNames('z-10', $$props.class);
+
+	onMount(() => {
+		triggerEls = [...document.querySelectorAll(triggers)];
+		if (!triggerEls.length) console.error('no triggers given');
+
+		triggerEls.forEach((node) => {
+			console.log(node, node.tabindex);
+			node.addEventListener('focusin', showHandler);
+			node.addEventListener('focusout', hideHandler);
+			if (clickable) {
+				node.addEventListener('click', showHandler);
+			} else {
+				node.addEventListener('mouseenter', showHandler);
+				node.addEventListener('mouseleave', hideHandler);
+			}
+		});
+
+		return () => {
+			triggerEl = undefined;
+			triggerEls.forEach((element: HTMLElement) => {
+				console.log('destroy', element);
+				element.removeEventListener('focusin', showHandler);
+				element.removeEventListener('focusout', hideHandler);
+				element.removeEventListener('click', showHandler);
+				element.removeEventListener('mouseenter', showHandler);
+				element.removeEventListener('mouseleave', hideHandler);
+			});
+		};
+	});
 </script>
 
-<div
-	bind:this={triggerEl}
-	on:focusin={showHandler}
-	on:focusout={hideHandler}
-	on:click={clickable ? showHandler : undefined}
-	on:mouseenter={clickable ? undefined : showHandler}
-	on:mouseleave={clickable ? undefined : hideHandler}
-	class="inline-block"
->
-	<slot name="trigger" />
-</div>
-<div
-	bind:this={contentEl}
-	role="tooltip"
-	tabindex={activeContent ? -1 : undefined}
-	class={divClass}
-	on:focusin={activeContent ? showHandler : undefined}
-	on:focusout={activeContent ? hideHandler : undefined}
-	on:mouseenter={activeContent && !clickable ? showHandler : undefined}
-	on:mouseleave={activeContent && !clickable ? hideHandler : undefined}
-	style="position: absolute;"
->
-	<slot />
-	{#if arrow}<div data-popper-arrow />{/if}
-</div>
+{#if open}
+	<div
+		use:init={open}
+		transition:fade={{ duration: 100, delay: 0 }}
+		role="tooltip"
+		tabindex={activeContent ? -1 : undefined}
+		class={divClass}
+		on:focusin={activeContent ? showHandler : undefined}
+		on:focusout={activeContent ? hideHandler : undefined}
+		on:mouseenter={activeContent && !clickable ? showHandler : undefined}
+		on:mouseleave={activeContent && !clickable ? hideHandler : undefined}
+		style="position: absolute;">
+		<slot />
+		{#if arrow}<div data-popper-arrow />{/if}
+	</div>
+{/if}

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { createPopper } from '@popperjs/core';
 	import classNames from 'classnames';
+	import type { Placement, Instance } from '@popperjs/core';
 
-	import type { Modifier, Placement, Instance, VirtualElement } from '@popperjs/core';
+	export let activeContent: boolean = false;
+	export let animation: false | number = 100;
+	export let arrow: boolean = true;
+	export let offset: number = 8;
+	export let placement: Placement = 'top';
+	export let trigger: 'hover' | 'click' = 'hover';
+	export let triggeredBy: string;
 
 	const dispatch = createEventDispatcher();
 
-	export let triggers: string;
-	export let open: boolean = false;
-
-	export let placement: Placement = 'top';
-	export let offset: number = 8;
-	export let trigger: 'hover' | 'click' = 'hover';
-	export let arrow: boolean = true;
-	// export let animation: false | `duration-${number}` = 'duration-3000';
-	export let activeContent: boolean;
+	let open: boolean = false;
 
 	let clickable: boolean;
 	$: clickable = trigger === 'click';
+
+	$: dispatch('show', open);
 
 	let triggerEl;
 	let triggerEls = [];
@@ -28,10 +29,7 @@
 	let _blocked: boolean = false; // managment of the race condition between focusin and click events
 	const block = () => ((_blocked = true), setTimeout(() => (_blocked = false), 250));
 
-	$: console.log(triggers, document.querySelectorAll(triggers));
-
 	const showHandler = (ev: Event) => {
-		console.log('show', ev.type, ev.target);
 		if (triggerEl === undefined) triggerEl = ev.target;
 		else if (triggerEls.includes(ev.target) && triggerEl !== ev.target) {
 			popper.state.elements.reference = ev.target as HTMLElement;
@@ -44,23 +42,22 @@
 	};
 
 	// typescript typeguards - poper.state.element.reference: Element|HTMLElement|VirtualElement
-	const hasHover = (x) => (x as Element).matches && (x as Element).matches(':hasHover');
-	const hasFocus = (x) =>
-		(x as Element).contains && (x as Element).contains(document.activeElement);
+	const hasHover = (el) => (el as Element).matches && (el as Element).matches(':hover');
+	const hasFocus = (el) =>
+		(el as Element).contains && (el as Element).contains(document.activeElement);
 
 	const hideHandler = (ev) => {
-		if (!_blocked)
+		if (activeContent) {
 			setTimeout(() => {
-				const elements = Object.values(popper.state.elements);
+				const elements = Object.values(popper?.state.elements ?? {});
 				if (ev.type === 'mouseleave' && elements.some(hasHover)) return;
 				if (ev.type === 'focusout' && elements.some(hasFocus)) return;
 				open = false;
 			}, 100);
+		} else open = false;
 	};
 
 	function init(node, _open) {
-		console.log('init', triggers, triggerEl);
-		// const popper: Instance = createPopper(triggerEl, node, {
 		popper = createPopper(triggerEl, node, {
 			placement,
 			modifiers: [
@@ -69,62 +66,36 @@
 			]
 		});
 		return {
-			update(_open) {
-				console.log('update');
-				updatePopper(popper);
-			},
 			destroy() {
-				console.log('destroy');
 				popper.destroy();
 			}
 		};
 	}
 
-	function enableListeners(modifiers: Modifier<any, any>[]) {
-		const modifier = modifiers.find((x) => x.name === 'eventListeners');
-		if (!modifier) return [...modifiers, { name: 'eventListeners', enabled: open }];
-		modifier.enabled = open;
-		return modifiers;
-	}
-
-	function updatePopper(popper: Instance) {
-		// Enable the event listeners
-		popper.setOptions(({ modifiers, ...options }) => ({
-			...options,
-			modifiers: enableListeners(modifiers)
-		}));
-		open && popper.update(); // Update the position
-		dispatch('show', open);
-	}
-
-	let divClass: string;
-	$: divClass = classNames('z-10', $$props.class);
-
 	onMount(() => {
-		triggerEls = [...document.querySelectorAll(triggers)];
+		const events: [string, any, boolean][] = [
+			['focusin', showHandler, true],
+			['focusout', hideHandler, true],
+			['click', showHandler, clickable],
+			['mouseenter', showHandler, !clickable],
+			['mouseleave', hideHandler, !clickable]
+		];
+
+		triggerEls = [...document.querySelectorAll(triggeredBy)];
 		if (!triggerEls.length) console.error('no triggers given');
 
-		triggerEls.forEach((node) => {
-			console.log(node, node.tabindex);
-			node.addEventListener('focusin', showHandler);
-			node.addEventListener('focusout', hideHandler);
-			if (clickable) {
-				node.addEventListener('click', showHandler);
-			} else {
-				node.addEventListener('mouseenter', showHandler);
-				node.addEventListener('mouseleave', hideHandler);
-			}
+		triggerEls.forEach((element: HTMLElement) => {
+			// trigger must be focusable
+			if (element.tabIndex < 0) element.tabIndex = 0;
+			for (const [name, handler, cond] of events) if (cond) element.addEventListener(name, handler);
 		});
 
 		return () => {
 			triggerEl = undefined;
 			triggerEls.forEach((element: HTMLElement) => {
-				console.log('destroy', element);
-				element.removeEventListener('focusin', showHandler);
-				element.removeEventListener('focusout', hideHandler);
-				element.removeEventListener('click', showHandler);
-				element.removeEventListener('mouseenter', showHandler);
-				element.removeEventListener('mouseleave', hideHandler);
+				if (element) {
+					for (const [name, handler, cond] of events) element.removeEventListener(name, handler);
+				}
 			});
 		};
 	});
@@ -133,10 +104,10 @@
 {#if open}
 	<div
 		use:init={open}
-		transition:fade={{ duration: 100, delay: 0 }}
+		transition:fade={{ duration: animation ? animation : 0 }}
 		role="tooltip"
-		tabindex={activeContent ? -1 : undefined}
-		class={divClass}
+		tabIndex={activeContent ? -1 : undefined}
+		class={classNames('z-10', $$props.class)}
 		on:focusin={activeContent ? showHandler : undefined}
 		on:focusout={activeContent ? hideHandler : undefined}
 		on:mouseenter={activeContent && !clickable ? showHandler : undefined}

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -524,7 +524,7 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 			<NavLi href="/contact">Contact</NavLi>
 		</NavUl>
 	</Navbar>
-      <Dropdown placement="bottom-start" triggers="#nav_dropdown" open={false}>
+      <Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open={false}>
         <DropdownItem>Dashboard</DropdownItem>
         <DropdownItem>Settings</DropdownItem>
         <DropdownItem>Earnings</DropdownItem>
@@ -716,7 +716,7 @@ Use the menu icon trigger element on components such as cards as an alternative 
   <ToolbarButton class="dots-menu text-gray-900 bg-white dark:text-white dark:bg-gray-800">
     <DotsVertical class="w-5 h-5"/>
   </ToolbarButton>
-<Dropdown class="w-44" triggers=".dots-menu">
+<Dropdown class="w-44" triggeredBy=".dots-menu">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
@@ -759,7 +759,7 @@ Use this example to show a list of notifications inside your application by prov
         <div class="inline-flex relative -top-2 right-3 w-3 h-3 bg-red-500 rounded-full border-2 border-white dark:border-gray-900"></div>
       </div>
     </div>
-  <Dropdown class="w-full max-w-sm" triggers="#bell">
+  <Dropdown class="w-full max-w-sm" triggeredBy="#bell">
     <ul slot="content" class="rounded divide-y divide-gray-100 shadow dark:bg-gray-800 dark:divide-gray-700">
       <DropdownHeader class="font-bold text-center"  divider={false}>Notifications</DropdownHeader>
       <DropdownItem class="flex space-x-4 ">
@@ -826,10 +826,9 @@ Use this example to show a list of notifications inside your application by prov
 
 This example can be used to show a list of menu items and options when a user is logged into your application.
 
-<ExampleDiv class="flex justify-between items-start h-64">
+<ExampleDiv class="flex justify-center items-start h-64">
   <Avatar class="acs" src="/images/profile-picture-3.webp" dot={{color:'bg-green-400'}} />
-  <Button class="acs">Test 2</Button>
-  <Dropdown triggers=".acs">
+  <Dropdown triggeredBy=".acs">
     <DropdownHeader>
       <span class="block text-sm"> Bonnie Green </span>
       <span class="block truncate text-sm font-medium"> name@flowbite.com </span>
@@ -843,8 +842,8 @@ This example can be used to show a list of menu items and options when a user is
 </ExampleDiv>
 
 ```html
-<Dropdown>
-  <Avatar slot="trigger" src="/images/profile-picture-3.webp" dot={{color:'bg-green-400'}} />
+<Avatar class="acs" src="/images/profile-picture-3.webp" dot={{color:'bg-green-400'}} />
+<Dropdown triggeredBy=".acs">
   <DropdownHeader>
     <span class="block text-sm"> Bonnie Green </span>
     <span class="block truncate text-sm font-medium"> name@flowbite.com </span>
@@ -862,11 +861,11 @@ This example can be used to show a list of menu items and options when a user is
 Use this example to also show the name or email of the user next to the avatar for the dropdown menu.
 
 <ExampleDiv class="flex justify-center items-start h-64">
-  <Button pill color="light" id="avatar_with_name">
+  <Button pill color="light" id="avatar_with_name" class="!p-1">
     <Avatar src="/images/profile-picture-3.webp" class="mr-2"/>
     Bonnie Green
   </Button>
-  <Dropdown inline triggers="#avatar_with_name">
+  <Dropdown inline triggeredBy="#avatar_with_name">
     <DropdownHeader>
       <span class="block text-sm"> Bonnie Green </span>
       <span class="block truncate text-sm font-medium"> name@flowbite.com </span>

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -5,8 +5,8 @@ layout: dropdownLayout
 <script>
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
   import { Avatar, Button, Checkbox, Label, Helper, Dropdown, DropdownDivider, DropdownHeader, DropdownItem,
-    Navbar,NavBrand,NavHamburger, NavUl, NavLi, Radio, Toggle, SimpleSearch, Breadcrumb, BreadcrumbItem, Badge, CloseButton } from '$lib'
-  import { ChevronDown, DotsHorizontal, DotsVertical, UserAdd, UserRemove } from 'svelte-heros';
+    Navbar,NavBrand,NavHamburger, NavUl, NavLi, Radio, Toggle, SimpleSearch, Breadcrumb, BreadcrumbItem, Badge, ToolbarButton } from '$lib'
+  import { Home, ChevronDown, DotsHorizontal, DotsVertical, UserAdd, UserRemove } from 'svelte-heros';
   
   import componentProps from '../props/Dropdown.json'
   import componentProps2 from '../props/DropdownDivider.json'
@@ -518,18 +518,19 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 		<NavHamburger on:click={toggle} />
 		<NavUl {hidden}>
 			<NavLi href="/" active={true}>Home</NavLi>
-      <Dropdown label="Dropdown" placement="bottom-start" inline={true} open={true}>
+      <NavLi href="#" id="nav_dropdown"><Button>Dropdown</Button></NavLi>
+			<NavLi href="/services">Services</NavLi>
+			<NavLi href="/pricing">Pricing</NavLi>
+			<NavLi href="/contact">Contact</NavLi>
+		</NavUl>
+	</Navbar>
+      <Dropdown placement="bottom-start" triggers="#nav_dropdown" open={false}>
         <DropdownItem>Dashboard</DropdownItem>
         <DropdownItem>Settings</DropdownItem>
         <DropdownItem>Earnings</DropdownItem>
         <DropdownDivider />
         <DropdownItem>Sign out</DropdownItem>
       </Dropdown>
-			<NavLi href="/services">Services</NavLi>
-			<NavLi href="/pricing">Pricing</NavLi>
-			<NavLi href="/contact">Contact</NavLi>
-		</NavUl>
-	</Navbar>
 </ExampleDiv>
 
 ```html
@@ -708,21 +709,14 @@ Use this example if you want to add a search bar inside the dropdown menu to be 
 
 Use the menu icon trigger element on components such as cards as an alternative element to the button.
 
-<ExampleDiv class="flex justify-center items-start gap-2 h-56">
-<Dropdown class="w-44">
-  <CloseButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
+<ExampleDiv class="flex justify-center items-start gap-2 h-60">
+  <ToolbarButton class="dots-menu text-gray-900 bg-white dark:text-white dark:bg-gray-800">
     <DotsHorizontal class="w-5 h-5"/>
-  </CloseButton>
-  <DropdownItem>Dashboard</DropdownItem>
-  <DropdownItem>Settings</DropdownItem>
-  <DropdownItem>Earnings</DropdownItem>
-  <DropdownDivider />
-  <DropdownItem>Sign out</DropdownItem>
-</Dropdown>
-<Dropdown class="w-44">
-  <CloseButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
+  </ToolbarButton>
+  <ToolbarButton class="dots-menu text-gray-900 bg-white dark:text-white dark:bg-gray-800">
     <DotsVertical class="w-5 h-5"/>
-  </CloseButton>
+  </ToolbarButton>
+<Dropdown class="w-44" triggers=".dots-menu">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
@@ -733,9 +727,9 @@ Use the menu icon trigger element on components such as cards as an alternative 
 
 ```html
 <Dropdown class="w-44">
-  <CloseButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
+  <ToolbarButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
     <DotsHorizontal class="w-5 h-5"/>
-  </CloseButton>
+  </ToolbarButton>
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
@@ -743,9 +737,9 @@ Use the menu icon trigger element on components such as cards as an alternative 
   <DropdownItem>Sign out</DropdownItem>
 </Dropdown>
 <Dropdown class="w-44">
-  <CloseButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
+  <ToolbarButton slot="trigger" class="text-gray-900 bg-white dark:text-white dark:bg-gray-800">
     <DotsVertical class="w-5 h-5"/>
-  </CloseButton>
+  </ToolbarButton>
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
@@ -759,13 +753,13 @@ Use the menu icon trigger element on components such as cards as an alternative 
 Use this example to show a list of notifications inside your application by providing more detailed information such as the user avatar, content and time of notification triggered by a notification bell icon.
 
 <ExampleDiv class="flex justify-center items-start h-56">
-  <Dropdown class="w-full max-w-sm">
-    <div slot="trigger" class="inline-flex items-center text-sm font-medium text-center text-gray-500 hover:text-gray-900 focus:outline-none dark:hover:text-white dark:text-gray-400">
+    <div id="bell" class="inline-flex items-center text-sm font-medium text-center text-gray-500 hover:text-gray-900 focus:outline-none dark:hover:text-white dark:text-gray-400">
       <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"></path></svg>
       <div class="flex relative">
         <div class="inline-flex relative -top-2 right-3 w-3 h-3 bg-red-500 rounded-full border-2 border-white dark:border-gray-900"></div>
       </div>
     </div>
+  <Dropdown class="w-full max-w-sm" triggers="#bell">
     <ul slot="content" class="rounded divide-y divide-gray-100 shadow dark:bg-gray-800 dark:divide-gray-700">
       <DropdownHeader class="font-bold text-center"  divider={false}>Notifications</DropdownHeader>
       <DropdownItem class="flex space-x-4 ">
@@ -832,9 +826,10 @@ Use this example to show a list of notifications inside your application by prov
 
 This example can be used to show a list of menu items and options when a user is logged into your application.
 
-<ExampleDiv class="flex justify-center items-start h-64">
-  <Dropdown>
-    <Avatar slot="trigger" src="/images/profile-picture-3.webp" dot={{color:'bg-green-400'}} />
+<ExampleDiv class="flex justify-between items-start h-64">
+  <Avatar class="acs" src="/images/profile-picture-3.webp" dot={{color:'bg-green-400'}} />
+  <Button class="acs">Test 2</Button>
+  <Dropdown triggers=".acs">
     <DropdownHeader>
       <span class="block text-sm"> Bonnie Green </span>
       <span class="block truncate text-sm font-medium"> name@flowbite.com </span>
@@ -867,11 +862,11 @@ This example can be used to show a list of menu items and options when a user is
 Use this example to also show the name or email of the user next to the avatar for the dropdown menu.
 
 <ExampleDiv class="flex justify-center items-start h-64">
-  <Dropdown inline>
-    <svelte:fragment slot="label" >
-      <Avatar src="/images/profile-picture-3.webp" class="mr-2"/>
-      Bonnie Green
-    </svelte:fragment>
+  <Button pill color="light" id="avatar_with_name">
+    <Avatar src="/images/profile-picture-3.webp" class="mr-2"/>
+    Bonnie Green
+  </Button>
+  <Dropdown inline triggers="#avatar_with_name">
     <DropdownHeader>
       <span class="block text-sm"> Bonnie Green </span>
       <span class="block truncate text-sm font-medium"> name@flowbite.com </span>

--- a/src/routes/popover/+page.md
+++ b/src/routes/popover/+page.md
@@ -4,7 +4,10 @@ layout: modalLayout
 
 <script>
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
-  import { Popover, Avatar, Breadcrumb, BreadcrumbItem, Button, ChevronRight } from '$lib'
+
+  import { Popover, Avatar, Breadcrumb, BreadcrumbItem, Button } from '$lib'
+  import { QuestionMarkCircle, ChevronRight } from 'svelte-heros';
+  import { Home } from 'svelte-heros';
   import componentProps from '../props/Popover.json'
 
   let props = componentProps.props
@@ -12,6 +15,7 @@ layout: modalLayout
   let divClass='w-full relative overflow-x-auto shadow-md sm:rounded-lg py-4'
   let theadClass ='text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-white'
   let click = false;
+  let placement;
 </script>
 
 <Breadcrumb>
@@ -42,8 +46,8 @@ Make sure that you have the Flowbite JavaScript included in your project to enab
 <Htwo label="Default popover" />
 
 <ExampleDiv  class="flex h-44 items-end justify-center">
-  <Popover class="w-64 text-sm font-light " title="Popover title">
-    <Button slot="trigger">Default popover</Button>
+  <Button  id="b1">Default popover</Button>
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggers="#b1">
       And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
@@ -60,7 +64,8 @@ Make sure that you have the Flowbite JavaScript included in your project to enab
 Use this example to show more information about a user profile when hovering over the trigger component.
 
 <ExampleDiv class="flex h-72 items-end justify-center">
-  <Popover class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+    <Button  id="b2">User profile</Button>
+  <Popover triggers="#b2" class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
     <div class="p-3">
         <div class="flex justify-between items-center mb-2">
             <Avatar href="/" src="/images/profile-picture-1.webp" alt="Jese Leos" />
@@ -88,7 +93,6 @@ Use this example to show more information about a user profile when hovering ove
             </li>
         </ul>
     </div>
-    <Button slot="trigger">User profile</Button>
   </Popover>
 </ExampleDiv>
 
@@ -98,8 +102,18 @@ Show helpful information inside a popover when hovering over a question mark but
 
 <ExampleDiv>
   <div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
+<<<<<<< HEAD
+<<<<<<< HEAD
+      <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
+    <Popover triggers="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
+=======
     <Popover class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
       <div slot="trigger"><svg class="ml-2 w-4 h-4 text-gray-400 hover:text-gray-500" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"></path></svg><span class="sr-only">Show information</span></div>
+>>>>>>> fd819fb5 (fix: update Alert color type)
+=======
+    <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
+    <Popover triggers="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
+>>>>>>> 951855dc (feat: popper reloaded)
       <div class="p-3 space-y-2">
           <h3 class="font-semibold text-gray-900 dark:text-white">Activity growth - Incremental</h3>
           Report helps navigate cumulative growth of community activities. Ideally, the chart should have a growing trend, as stagnating chart signifies a significant decrease of community activity.
@@ -131,20 +145,11 @@ Show helpful information inside a popover when hovering over a question mark but
 Set the position of the popover component relative to the trigger element by using the `placement={top|right|bottom|left}` data attribute and its values.
 
 <ExampleDiv class="flex gap-4">
-  <Popover placement="top" class="w-64 text-sm font-light " title="Popover top">
-    <Button slot="trigger">Top popover</Button>
-      And here's some amazing content. It's very engaging. Right?
-  </Popover>
-  <Popover placement="right" class="w-64 text-sm font-light " title="Popover right">
-    <Button slot="trigger">Right popover</Button>
-      And here's some amazing content. It's very engaging. Right?
-  </Popover>
-  <Popover placement="bottom" class="w-64 text-sm font-light " title="Popover bottom">
-    <Button slot="trigger">Bottom popover</Button>
-      And here's some amazing content. It's very engaging. Right?
-  </Popover>
-  <Popover placement="left" class="w-64 text-sm font-light " title="Popover left">
-    <Button slot="trigger">Left popover</Button>
+  <Button id="bp4" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
+  <Button id="bp1" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
+  <Button id="bp3" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
+  <Button id="bp2" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
+  <Popover triggers="#bp1,#bp2, #bp3,#bp4" {placement} class="w-64 text-sm font-light " title="Popover left">
       And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
@@ -167,6 +172,16 @@ Set the position of the popover component relative to the trigger element by usi
     And here's some amazing content. It's very engaging. Right?
 </Popover>
 ```
+
+<Htwo label="Triggering" />
+
+<ExampleDiv>
+  <Button id='click'>Click popover</Button>
+  <Button id='click1'>Click popover</Button>
+    <Popover class="w-64 text-sm font-light " title="Popover title" triggers="#click,#click1" trigger="click">
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+</ExampleDiv>
 
 <Htwo label="Props" />
 

--- a/src/routes/popover/+page.md
+++ b/src/routes/popover/+page.md
@@ -47,16 +47,16 @@ Make sure that you have the Flowbite JavaScript included in your project to enab
 
 <ExampleDiv  class="flex h-44 items-end justify-center">
   <Button  id="b1">Default popover</Button>
-  <Popover class="w-64 text-sm font-light " title="Popover title" triggers="#b1">
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#b1">
       And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
 
 ```html
-<Popover class="w-64 text-sm font-light " title="Popover title">
-  <Button slot="trigger">Default popover</Button>
-    And here's some amazing content. It's very engaging. Right?
-</Popover>
+  <Button  id="b1">Default popover</Button>
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#b1">
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
 ```
 
 <Htwo label="User profile" />
@@ -64,8 +64,8 @@ Make sure that you have the Flowbite JavaScript included in your project to enab
 Use this example to show more information about a user profile when hovering over the trigger component.
 
 <ExampleDiv class="flex h-72 items-end justify-center">
-    <Button  id="b2">User profile</Button>
-  <Popover triggers="#b2" class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+  <Button  id="b2">User profile</Button>
+  <Popover triggeredBy="#b2" class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
     <div class="p-3">
         <div class="flex justify-between items-center mb-2">
             <Avatar href="/" src="/images/profile-picture-1.webp" alt="Jese Leos" />
@@ -96,39 +96,48 @@ Use this example to show more information about a user profile when hovering ove
   </Popover>
 </ExampleDiv>
 
+```html
+<Button  id="b2">User profile</Button>
+<Popover triggeredBy="#b2" class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+  <div class="p-3">
+      <div class="flex justify-between items-center mb-2">
+          <Avatar href="/" src="/images/profile-picture-1.webp" alt="Jese Leos" />
+          <Button size="xs">Follow</Button>
+      </div>
+      <div class="text-base font-semibold leading-none text-gray-900 dark:text-white">
+          <a href="/">Jese Leos</a>
+      </div>
+      <div class="mb-3 text-sm font-normal">
+          <a href="/" class="hover:underline">@jeseleos</a>
+      </div>
+      <div class="mb-4 text-sm font-light">Open-source contributor. Building <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">flowbite.com</a>.</div>
+      <ul class="flex text-sm font-light">
+          <li class="mr-2">
+              <a href="/" class="hover:underline">
+                  <span class="font-semibold text-gray-900 dark:text-white">799</span>
+                  <span>Following</span>
+              </a>
+          </li>
+          <li>
+              <a href="/" class="hover:underline">
+                  <span class="font-semibold text-gray-900 dark:text-white">3,758</span>
+                  <span>Followers</span>
+              </a>
+          </li>
+      </ul>
+  </div>
+</Popover>
+```
+
 <Htwo label="Description popover" />
 
 Show helpful information inside a popover when hovering over a question mark button.
 
 <ExampleDiv>
   <div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
-<<<<<<< HEAD
-<<<<<<< HEAD
-      <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
-    <Popover triggers="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
-=======
-    <Popover class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
-      <div slot="trigger"><svg class="ml-2 w-4 h-4 text-gray-400 hover:text-gray-500" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"></path></svg><span class="sr-only">Show information</span></div>
->>>>>>> fd819fb5 (fix: update Alert color type)
-=======
     <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
-    <Popover triggers="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
->>>>>>> 951855dc (feat: popper reloaded)
-      <div class="p-3 space-y-2">
-          <h3 class="font-semibold text-gray-900 dark:text-white">Activity growth - Incremental</h3>
-          Report helps navigate cumulative growth of community activities. Ideally, the chart should have a growing trend, as stagnating chart signifies a significant decrease of community activity.
-          <h3 class="font-semibold text-gray-900 dark:text-white">Calculation</h3>
-          For each date bucket, the all-time volume of activities is calculated. This means that activities in period n contain all activities up to period n, plus the activities generated by your community in period.
-          <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">Read more <ChevronRight size="12" /></a>
-      </div>
-    </Popover>
   </div>
-</ExampleDiv>
-
-```html
-<div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
-  <Popover class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
-    <div slot="trigger"><svg class="ml-2 w-4 h-4 text-gray-400 hover:text-gray-500" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"></path></svg><span class="sr-only">Show information</span></div>
+  <Popover triggeredBy="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
     <div class="p-3 space-y-2">
         <h3 class="font-semibold text-gray-900 dark:text-white">Activity growth - Incremental</h3>
         Report helps navigate cumulative growth of community activities. Ideally, the chart should have a growing trend, as stagnating chart signifies a significant decrease of community activity.
@@ -137,7 +146,21 @@ Show helpful information inside a popover when hovering over a question mark but
         <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">Read more <ChevronRight size="12" /></a>
     </div>
   </Popover>
+</ExampleDiv>
+
+```html
+<div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
+  <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
 </div>
+<Popover triggeredBy="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
+  <div class="p-3 space-y-2">
+      <h3 class="font-semibold text-gray-900 dark:text-white">Activity growth - Incremental</h3>
+      Report helps navigate cumulative growth of community activities. Ideally, the chart should have a growing trend, as stagnating chart signifies a significant decrease of community activity.
+      <h3 class="font-semibold text-gray-900 dark:text-white">Calculation</h3>
+      For each date bucket, the all-time volume of activities is calculated. This means that activities in period n contain all activities up to period n, plus the activities generated by your community in period.
+      <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">Read more <ChevronRight size="12" /></a>
+  </div>
+</Popover>
 ```
 
 <Htwo label="Placement" />
@@ -145,43 +168,42 @@ Show helpful information inside a popover when hovering over a question mark but
 Set the position of the popover component relative to the trigger element by using the `placement={top|right|bottom|left}` data attribute and its values.
 
 <ExampleDiv class="flex gap-4">
-  <Button id="bp4" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
-  <Button id="bp1" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
-  <Button id="bp3" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
-  <Button id="bp2" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
-  <Popover triggers="#bp1,#bp2, #bp3,#bp4" {placement} class="w-64 text-sm font-light " title="Popover left">
+  <Button id="placement-left" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
+  <Button id="placement-top2" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
+  <Button id="placement-bottom" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
+  <Button id="placement-right" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
+  <Popover triggeredBy="[id^='placement-']" {placement} class="w-64 text-sm font-light " title="Popover left">
       And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
 
 ```html
-<Popover placement="top" class="w-64 text-sm font-light " title="Popover top">
-  <Button slot="trigger">Top popover</Button>
-    And here's some amazing content. It's very engaging. Right?
-</Popover>
-<Popover placement="right" class="w-64 text-sm font-light " title="Popover right">
-  <Button slot="trigger">Right popover</Button>
-    And here's some amazing content. It's very engaging. Right?
-</Popover>
-<Popover placement="bottom" class="w-64 text-sm font-light " title="Popover bottom">
-  <Button slot="trigger">Bottom popover</Button>
-    And here's some amazing content. It's very engaging. Right?
-</Popover>
-<Popover placement="left" class="w-64 text-sm font-light " title="Popover left">
-  <Button slot="trigger">Left popover</Button>
-    And here's some amazing content. It's very engaging. Right?
-</Popover>
+  <Button id="placement-left" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
+  <Button id="placement-top2" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
+  <Button id="placement-bottom" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
+  <Button id="placement-right" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
+  <Popover triggeredBy="[id^='placement-']" {placement} class="w-64 text-sm font-light " title="Popover left">
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
 ```
 
 <Htwo label="Triggering" />
 
 <ExampleDiv>
   <Button id='click'>Click popover</Button>
-  <Button id='click1'>Click popover</Button>
-    <Popover class="w-64 text-sm font-light " title="Popover title" triggers="#click,#click1" trigger="click">
-      And here's some amazing content. It's very engaging. Right?
+  <Button id='click1' color="green">Another click popover</Button>
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click,#click1" trigger="click">
+    And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
+
+```html
+<Button id='click'>Click popover</Button>
+<Button id='click1' color="green">Another click popover</Button>
+<Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click,#click1" trigger="click">
+  And here's some amazing content. It's very engaging. Right?
+</Popover>
+```
 
 <Htwo label="Props" />
 

--- a/src/routes/popover/+page.md
+++ b/src/routes/popover/+page.md
@@ -5,8 +5,9 @@ layout: modalLayout
 <script>
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
 
-  import { Popover, Avatar, Breadcrumb, BreadcrumbItem, Button } from '$lib'
-  import { QuestionMarkCircle, ChevronRight } from 'svelte-heros';
+  import { Popover, Avatar, Breadcrumb, BreadcrumbItem, Button, Input, Label, Checkbox } from '$lib'
+  import  ChevronRight  from "$lib/utils/ChevronRight.svelte";
+  import { QuestionMarkCircle, Check, X } from 'svelte-heros';
   import { Home } from 'svelte-heros';
   import componentProps from '../props/Popover.json'
 
@@ -135,7 +136,7 @@ Show helpful information inside a popover when hovering over a question mark but
 
 <ExampleDiv>
   <div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
-    <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
+    <button id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></button>
   </div>
   <Popover triggeredBy="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
     <div class="p-3 space-y-2">
@@ -148,9 +149,9 @@ Show helpful information inside a popover when hovering over a question mark but
   </Popover>
 </ExampleDiv>
 
-```html
+```svelte
 <div class="flex items-center text-sm font-light text-gray-500 dark:text-gray-400">This is just some informational text
-  <div id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></div>
+  <button id="b3"><QuestionMarkCircle class="ml-1 w-4 h-4" variation="solid"/><span class="sr-only">Show information</span></button>
 </div>
 <Popover triggeredBy="#b3" class="w-72 text-sm font-light text-gray-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400" placement="bottom-start">
   <div class="p-3 space-y-2">
@@ -163,47 +164,178 @@ Show helpful information inside a popover when hovering over a question mark but
 </Popover>
 ```
 
+<Htwo label="Progress popover" />
+
+Show a progress bar with details inside a popover when hovering over a settings button.
+
+<ExampleDiv>
+<Button id="progress"><svg class="mr-2 w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"></path><path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"></path><path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"></path></svg> Storage status</Button>
+<Popover triggeredBy="#progress" class="text-sm w-64 font-light">
+  <div class="space-y-2">
+    <h3 class="font-semibold text-gray-900 dark:text-white">Available storage</h3>
+    <p class="text-gray-500 dark:text-gray-400">This server has <span class="font-semibold text-gray-900 dark:text-white">30</span> of <span class="font-semibold text-gray-900 dark:text-white">150 GB</span> of block storage remaining.</p>
+    <div class="w-full bg-gray-200 rounded-full h-2.5 mb-4 dark:bg-gray-700">
+        <div class="bg-red-600 h-2.5 rounded-full" style="width: 85%"></div>
+    </div>
+    <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">
+      Upgrade now <ChevronRight size="12" variation="solid"/>
+    </a>
+  </div>
+</Popover>
+</ExampleDiv>
+
+<Htwo label="Password strength" />
+
+Dynamically show the password strength progress when creating a new password positioned relative to the input element.
+
+<ExampleDiv>
+<form on:submit|preventDefault>
+  <div class="mb-6">
+    <Label for="email" class="mb-2">Your email</Label>
+    <Input type="email" id="email" placeholder="name@flowbite.com" required="" />
+  </div>
+  <div class="mb-6">
+    <Label for="password" class="mb-2">Your password</Label>
+    <Input type="password" id="password" required="" />
+  </div>
+  <Checkbox class="mb-6">Remember me</Checkbox>
+  <Button type="submit">Submit</Button>
+</form>
+<Popover class="text-sm" triggeredBy="#password" placement="bottom">
+  <h3 class="font-semibold text-gray-900 dark:text-white">Must have at least 6 characters</h3>
+  <div class="grid grid-cols-4 gap-2">
+      <div class="h-1 bg-orange-300 dark:bg-orange-400"></div>
+      <div class="h-1 bg-orange-300 dark:bg-orange-400"></div>
+      <div class="h-1 bg-gray-200 dark:bg-gray-600"></div>
+      <div class="h-1 bg-gray-200 dark:bg-gray-600"></div>
+  </div>
+  <p class="py-2">It’s better to have:</p>
+  <ul>
+      <li class="flex items-center mb-1">
+          <Check class="mr-2 w-4 h-4 text-green-400 dark:text-green-500" />Upper &amp; lower case letters 
+      </li>
+      <li class="flex items-center mb-1">
+          <X class="mr-2 w-4 h-4 text-gray-300 dark:text-gray-400"/>A symbol (#$&amp;) 
+      </li>
+      <li class="flex items-center">
+          <X class="mr-2 w-4 h-4 text-gray-300 dark:text-gray-400"/>A longer password (min. 12 chars.)
+      </li>
+  </ul>
+</Popover>
+</ExampleDiv>
+
+```html
+<form on:submit|preventDefault>
+  <div class="mb-6">
+    <Label for="email" class="mb-2">Your email</Label>
+    <Input type="email" id="email" placeholder="name@flowbite.com" required="" />
+  </div>
+  <div class="mb-6">
+    <Label for="password" class="mb-2">Your password</Label>
+    <Input type="password" id="password" required="" />
+  </div>
+  <Checkbox class="mb-6">Remember me</Checkbox>
+  <Button type="submit">Submit</Button>
+</form>
+<Popover class="text-sm" triggeredBy="#password" placement="bottom">
+  <h3 class="font-semibold text-gray-900 dark:text-white">Must have at least 6 characters</h3>
+  <div class="grid grid-cols-4 gap-2">
+      <div class="h-1 bg-orange-300 dark:bg-orange-400"></div>
+      <div class="h-1 bg-orange-300 dark:bg-orange-400"></div>
+      <div class="h-1 bg-gray-200 dark:bg-gray-600"></div>
+      <div class="h-1 bg-gray-200 dark:bg-gray-600"></div>
+  </div>
+  <p class="py-2">It’s better to have:</p>
+  <ul>
+      <li class="flex items-center mb-1">
+          <Check class="mr-2 w-4 h-4 text-green-400 dark:text-green-500" />Upper &amp; lower case letters 
+      </li>
+      <li class="flex items-center mb-1">
+          <X class="mr-2 w-4 h-4 text-gray-300 dark:text-gray-400"/>A symbol (#$&amp;) 
+      </li>
+      <li class="flex items-center">
+          <X class="mr-2 w-4 h-4 text-gray-300 dark:text-gray-400"/>A longer password (min. 12 chars.)
+      </li>
+  </ul>
+</Popover>
+```
+
 <Htwo label="Placement" />
 
 Set the position of the popover component relative to the trigger element by using the `placement={top|right|bottom|left}` data attribute and its values.
 
 <ExampleDiv class="flex gap-4">
-  <Button id="placement-left" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
-  <Button id="placement-top2" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
-  <Button id="placement-bottom" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
-  <Button id="placement-right" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
+  <Button id="placement-left" on:mouseenter={()=> placement="left"}>Left popover</Button>
+  <Button id="placement-top" on:mouseenter={()=> placement="top"}>Top popover</Button>
+  <Button id="placement-bottom" on:mouseenter={()=> placement="bottom"}>Bottom popover</Button>
+  <Button id="placement-right" on:mouseenter={()=> placement="right"}>Right popover</Button>
   <Popover triggeredBy="[id^='placement-']" {placement} class="w-64 text-sm font-light " title="Popover left">
       And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
 
-```html
-  <Button id="placement-left" on:mouseenter={()=> placement = 'left'}>Left popover</Button>
-  <Button id="placement-top2" on:mouseenter={()=> placement = 'top'}>Top popover</Button>
-  <Button id="placement-bottom" on:mouseenter={()=> placement = 'bottom'}>Bottom popover</Button>
-  <Button id="placement-right" on:mouseenter={()=> placement = 'right'}>Right popover</Button>
-  <Popover triggeredBy="[id^='placement-']" {placement} class="w-64 text-sm font-light " title="Popover left">
-      And here's some amazing content. It's very engaging. Right?
-  </Popover>
+```svelte
+<Button id="placement-left" on:mouseenter={()=> placement="left"}>Left popover</Button>
+<Button id="placement-top" on:mouseenter={()=> placement="top"}>Top popover</Button>
+<Button id="placement-bottom" on:mouseenter={()=> placement="bottom"}>Bottom popover</Button>
+<Button id="placement-right" on:mouseenter={()=> placement="right"}>Right popover</Button>
+<Popover triggeredBy="[id^='placement-']" {placement} class="w-64 text-sm font-light " title="Popover left">
+    And here's some amazing content. It's very engaging. Right?
+</Popover>
 ```
 
 <Htwo label="Triggering" />
 
 <ExampleDiv>
+  <Button id='hover'>Hover popover</Button>
   <Button id='click'>Click popover</Button>
-  <Button id='click1' color="green">Another click popover</Button>
-  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click,#click1" trigger="click">
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#hover" trigger="hover">
+    And here's some amazing content. It's very engaging. Right?
+  </Popover>
+  <Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click" trigger="click">
     And here's some amazing content. It's very engaging. Right?
   </Popover>
 </ExampleDiv>
 
 ```html
+<Button id='hover'>Hover popover</Button>
 <Button id='click'>Click popover</Button>
-<Button id='click1' color="green">Another click popover</Button>
-<Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click,#click1" trigger="click">
+<Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#hover" trigger="hover">
+  And here's some amazing content. It's very engaging. Right?
+</Popover>
+<Popover class="w-64 text-sm font-light " title="Popover title" triggeredBy="#click" trigger="click">
   And here's some amazing content. It's very engaging. Right?
 </Popover>
 ```
+
+<Htwo label="Offset" />
+
+Increase or decrease the default offset by adding the `offset` attribute where the value is an integer.
+
+<ExampleDiv  class="flex h-52 items-end justify-center">
+  <Button  id="offset">Default popover</Button>
+  <Popover offset="30" class="w-64 text-sm font-light" title="Popover title" triggeredBy="#offset">
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+</ExampleDiv>
+
+```html
+<Button  id="offset">Default popover</Button>
+<Popover offset="30" class="w-64 text-sm font-light" title="Popover title" triggeredBy="#offset">
+    And here's some amazing content. It's very engaging. Right?
+</Popover>
+```
+
+<Htwo label="Disable arrow" />
+
+You can also disable the popover arrow by setting `arrow` attribute to `false`.
+
+<ExampleDiv  class="flex h-44 items-end justify-center">
+  <Button  id="arrow">Default popover</Button>
+  <Popover arrow={false} class="w-64 text-sm font-light" title="Popover title" triggeredBy="#arrow">
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+</ExampleDiv>
 
 <Htwo label="Props" />
 

--- a/src/routes/tooltips/+page.md
+++ b/src/routes/tooltips/+page.md
@@ -42,9 +42,8 @@ Flowbite-Svelte allows you to show extra information when hovering or focusing o
 <Htwo label="Default tooltip example" />
 
 <ExampleDiv>
-  <Tooltip content="Tooltip content">
-    <Button>Default tooltip</Button>
-  </Tooltip>
+<Button id="default">Default tooltip</Button>
+<Tooltip content="Tooltip content" triggeredBy='#default'/>
 </ExampleDiv>
 
 ```html
@@ -52,8 +51,8 @@ Flowbite-Svelte allows you to show extra information when hovering or focusing o
 import {Tooltip, Button} from 'flowbite-svelte'
 </script>
 
-<Tooltip content="Tooltip content">
-  <Button>Default tooltip</Button>
+<Button id="default">Default tooltip</Button>
+<Tooltip content="Tooltip content" triggeredBy='#default'>
 </Tooltip>
 ```
 
@@ -137,7 +136,7 @@ import {Tooltip, Button} from 'flowbite-svelte'
 
 <Htwo label="Disable arrow" />
 
-<ExampleDiv>
+<ExampleDiv class="flex">
   <Tooltip content="Tooltip content" arrow={false}>
     <Button>Default tooltip</Button>
   </Tooltip>
@@ -153,11 +152,11 @@ import {Tooltip, Button} from 'flowbite-svelte'
 
 When you want to add custom styles, use `style="custom"`, `tipClass`, and `tipColor` to modify the style.
 
-<ExampleDiv>
+<ExampleDiv class="flex">
   <Tooltip
 		content="tooltip content"
 		placement="auto"
-		tipClass="absolute inline-block rounded-lg p-24 text-lg font-medium shadow-sm text-white"
+		tipClass="rounded-lg p-24 text-lg font-medium shadow-sm text-white"
 		style="custom"
 		tipColor="bg-red-900 dark:bg-red-700"
 	>


### PR DESCRIPTION
## 📑 Description
`Popper` re-written. **Breaking changes**
Features:
- decouple content from trigger - connection made via css query specified in `triggeredBy` parameter
- multiple trigger elements possible - `Popper` can be re-used from different places in the document
- use of the `fade` animation function from svelte instead of `transition-opacity`
- use of svelte `if` directive instead of `visible opacity` classes
- `createPopper` called only when content is open

Can you please do some testing before merge? 
@AlessioGr can you check the behavior with SSR rendering? 

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
`Dropdown`, `Tooltip`, `Popover` - old API left and some docs require further updates.
