### PR TITLE
feat: frame abstraction

### DIFF
--- a/src/lib/alerts/Alert.svelte
+++ b/src/lib/alerts/Alert.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
 	import classNames from 'classnames';
 	import { createEventDispatcher } from 'svelte';
-	import type { SvelteComponent } from 'svelte';
 	import CloseButton from '../utils/CloseButton.svelte';
+	import Frame from '$lib/utils/Frame.svelte';
 
 	const dispatch = createEventDispatcher();
-	setContext('background', true);
 
 	export let color:
 		| 'gray'
@@ -36,58 +34,11 @@
 		hidden = !hidden;
 	};
 
-	const bgClasses = {
-		gray: 'bg-gray-100 dark:bg-gray-200 ',
-		red: 'bg-red-100 dark:bg-red-200',
-		yellow: 'bg-yellow-100 dark:bg-yellow-200 ',
-		green: 'bg-green-100 dark:bg-green-200 ',
-		indigo: 'bg-indigo-100 dark:bg-indigo-200 ',
-		purple: 'bg-purple-100 dark:bg-purple-200 ',
-		pink: 'bg-pink-100 dark:bg-pink-200 ',
-		blue: 'bg-blue-100 dark:bg-blue-200 ',
-		dark: 'bg-gray-50 dark:bg-gray-700',
-		custom: customBgClass
-	};
-
-	const borderAccentClasses = {
-		gray: 'border-gray-500 dark:bg-gray-200 ',
-		red: 'border-red-500 dark:bg-red-200 ',
-		yellow: 'border-yellow-500 dark:bg-tellow-200 ',
-		green: 'border-green-500 dark:bg-green-200 ',
-		indigo: 'border-indigo-500 dark:bg-indigo-200 ',
-		purple: 'border-purple-500 dark:bg-purple-200 ',
-		pink: 'border-pink-500 dark:bg-pink-200 ',
-		blue: 'border-blue-500 dark:bg-blue-200 ',
-		dark: 'border-gray-500',
-		custom: customBorderAccentClass
-	};
-
-	const textColors = {
-		gray: 'text-gray-700 dark:text-gray-800',
-		red: 'text-red-700 dark:text-red-800',
-		yellow: 'text-yellow-700 dark:text-yellow-800',
-		green: 'text-green-700 dark:text-green-800',
-		indigo: 'text-indigo-700 dark:text-indigo-800',
-		purple: 'text-purple-700 dark:text-purple-800',
-		pink: 'text-pink-700 dark:text-pink-800',
-		blue: 'text-blue-700 dark:text-blue-800',
-		dark: 'text-gray-700  dark:text-gray-300',
-		custom: customTextColor
-	};
-
 	let divClass: string;
-	$: divClass = classNames(
-		'p-4 text-sm',
-		bgClasses[color] ?? bgClasses.blue,
-		accent && (borderAccentClasses[color] ?? borderAccentClasses.blue),
-		rounded && 'rounded-lg ',
-		accent && 'border-t-4 ',
-		textColors[color],
-		$$props.class
-	);
+	$: divClass = classNames('p-4 text-sm', accent && 'border-t-4 ', hidden && 'hidden', $$props.class);
 </script>
 
-<div id={$$props.id} class:hidden class={divClass} role="alert">
+<Frame {color} {rounded} {...$$restProps} class={divClass} role="alert">
 	<div class="flex items-center whitespace-pre-wrap">
 		{#if $$slots.icon}
 			<slot name="icon" />
@@ -112,4 +63,4 @@
 		{/if}
 	</div>
 	<slot name="extra" />
-</div>
+</Frame>

--- a/src/lib/alerts/Alert.svelte
+++ b/src/lib/alerts/Alert.svelte
@@ -23,12 +23,10 @@
 
 	let hidden = false;
 
-	const handleAlert = () => {
-		dispatch('handleAlert');
-	};
-
 	const handleHide = () => {
 		hidden = !hidden;
+		dispatch('handleAlert');
+		dispatch('close'); // preffered name
 	};
 
 	let divClass: string;
@@ -48,7 +46,6 @@
 				class="-mx-1.5 -my-1.5"
 				{color}
 				on:click={handleHide}
-				on:click={handleAlert}
 				on:click
 				on:change
 				on:keydown

--- a/src/lib/alerts/Alert.svelte
+++ b/src/lib/alerts/Alert.svelte
@@ -20,9 +20,6 @@
 	export let dismissable: boolean = false;
 	export let rounded: boolean = true;
 	export let accent: boolean = false;
-	export let customBgClass: string = '';
-	export let customBorderAccentClass: string = '';
-	export let customTextColor: string = '';
 
 	let hidden = false;
 

--- a/src/lib/cards/Card.svelte
+++ b/src/lib/cards/Card.svelte
@@ -31,6 +31,7 @@
 	let cardClass;
 	$: cardClass = classNames(
 		'flex',
+		sizes[size],
 		reverse ? 'flex-col-reverse' : 'flex-col',
 		horizontal && (reverse ? 'md:flex-row-reverse md:max-w-xl' : 'md:flex-row md:max-w-xl'),
 		href && 'hover:bg-gray-100 dark:hover:bg-gray-700',
@@ -46,15 +47,13 @@
 	);
 </script>
 
-<Frame class={sizes[size]} rounded shadow border>
-	<svelte:element this={href ? 'a' : 'div'} {href} class={cardClass}>
-		{#if img}
-			<img class={imgClass} src={img} alt="" />
-			<div class={innerPdding}>
-				<slot />
-			</div>
-		{:else}
+<Frame tag={href ? 'a' : 'div'} rounded shadow border {href} class={cardClass}>
+	{#if img}
+		<img class={imgClass} src={img} alt="" />
+		<div class={innerPdding}>
 			<slot />
-		{/if}
-	</svelte:element>
+		</div>
+	{:else}
+		<slot />
+	{/if}
 </Frame>

--- a/src/lib/cards/Card.svelte
+++ b/src/lib/cards/Card.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import classNames from 'classnames';
-	import { setContext } from 'svelte';
+	import Frame from '$lib/utils/Frame.svelte';
 
 	export let href: string = undefined;
 	export let horizontal: boolean = false;
@@ -8,8 +8,6 @@
 	export let img: string = undefined;
 	export let padding: 'none' | 'sm' | 'md' | 'lg' = 'lg';
 	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'sm';
-
-	setContext('background', true);
 
 	const paddings = {
 		none: 'p-0',
@@ -33,12 +31,8 @@
 	let cardClass;
 	$: cardClass = classNames(
 		'flex',
-		sizes[size],
 		reverse ? 'flex-col-reverse' : 'flex-col',
 		horizontal && (reverse ? 'md:flex-row-reverse md:max-w-xl' : 'md:flex-row md:max-w-xl'),
-		'bg-white dark:bg-gray-800 shadow-md',
-		'text-gray-500 dark:text-gray-400',
-		'rounded-lg border border-gray-200 dark:border-gray-700',
 		href && 'hover:bg-gray-100 dark:hover:bg-gray-700',
 		!img && innerPdding,
 		$$props.class
@@ -52,13 +46,15 @@
 	);
 </script>
 
-<svelte:element this={href ? 'a' : 'div'} {href} class={cardClass}>
-	{#if img}
-		<img class={imgClass} src={img} alt="" />
-		<div class={innerPdding}>
+<Frame class={sizes[size]} rounded shadow border>
+	<svelte:element this={href ? 'a' : 'div'} {href} class={cardClass}>
+		{#if img}
+			<img class={imgClass} src={img} alt="" />
+			<div class={innerPdding}>
+				<slot />
+			</div>
+		{:else}
 			<slot />
-		</div>
-	{:else}
-		<slot />
-	{/if}
-</svelte:element>
+		{/if}
+	</svelte:element>
+</Frame>

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -62,7 +62,6 @@
 	activeContent={true}
 	arrow={false}
 	{placement}
-	{...$$restProps}
 	trigger="click"
 	on:show
 	bind:open

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
 	import Button from '$lib/buttons/Button.svelte';
+	import Frame from '$lib/utils/Frame.svelte';
 	import Popper from '$lib/utils/Popper.svelte';
 	import classNames from 'classnames';
 	import ChevronUp from '../utils/ChevronUp.svelte';
@@ -21,8 +21,6 @@
 
 	let id = generateId();
 
-	setContext('background', true);
-
 	const icons = {
 		top: ChevronUp,
 		right: ChevronRight,
@@ -33,14 +31,7 @@
 	$: icon = icons[placement.split('-')[0]];
 
 	let popoverClass;
-	$: popoverClass = classNames(
-		'rounded-lg shadow-sm',
-		'bg-white dark:bg-gray-800',
-		'text-gray-500 dark:text-gray-400',
-		'border border-gray-200 dark:border-gray-700',
-		'outline-none',
-		$$props.class
-	);
+	$: popoverClass = classNames('outline-none', $$props.class);
 </script>
 
 {#if label}
@@ -72,14 +63,15 @@
 	arrow={false}
 	{placement}
 	{...$$restProps}
-	class={popoverClass}
 	trigger="click"
 	on:show
 	bind:open
 	triggeredBy={triggeredBy ?? '#' + id}>
-	<slot name="content">
-		<ul class="py-1">
-			<slot />
-		</ul>
-	</slot>
+	<Frame class={popoverClass} rounded border shadow>
+		<slot name="content">
+			<ul class="py-1">
+				<slot />
+			</ul>
+		</slot>
+	</Frame>
 </Popper>

--- a/src/lib/list-group/List.svelte
+++ b/src/lib/list-group/List.svelte
@@ -3,26 +3,21 @@
 	import classNames from 'classnames';
 	import type { ListGroupItemType } from '$lib/types';
 	import ListItem from './ListItem.svelte';
+	import Frame from '$lib/utils/Frame.svelte';
 
 	export let items: ListGroupItemType[] = [];
 	export let active: boolean = false;
 
-	setContext('background', true);
 	$: setContext('active', active);
 
 	let groupClass: string;
-	$: groupClass = classNames(
-		'text-gray-900 bg-white dark:text-gray-200 dark:bg-gray-700',
-		'rounded-lg border border-gray-200 dark:border-gray-600',
-		'divide-y divide-gray-200 dark:divide-gray-600',
-		$$props.class
-	);
+	$: groupClass = classNames('divide-y divide-gray-200 dark:divide-gray-600', $$props.class);
 </script>
 
-<svelte:element this={active ? 'div' : 'ul'} class={groupClass}>
+<Frame tag={active ? 'div' : 'ul'} rounded border class={groupClass}>
 	{#each items as item, index}
 		<ListItem {active} {...item} {index} on:click><slot {item} {index} /></ListItem>
 	{:else}
 		<slot />
 	{/each}
-</svelte:element>
+</Frame>

--- a/src/lib/modals/Modal.svelte
+++ b/src/lib/modals/Modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { createEventDispatcher, setContext } from 'svelte';
+	import Frame from '$lib/utils/Frame.svelte';
+	import { createEventDispatcher } from 'svelte';
 	import CloseButton from '../utils/CloseButton.svelte';
 	import focusTrap from '../utils/focusTrap';
 
@@ -17,11 +18,9 @@
 		| 'bottom-center'
 		| 'bottom-right' = 'center';
 	export let autoclose: boolean = true;
-	export let backdropClasses: string =
-		'bg-gray-900 bg-opacity-50 dark:bg-opacity-80 fixed inset-0 z-40';
+	export let backdropClasses: string = 'bg-gray-900 bg-opacity-50 dark:bg-opacity-80 fixed inset-0 z-40';
 
 	const dispatch = createEventDispatcher();
-	setContext('background', true);
 
 	const allPlacementClasses = [
 		'justify-start',
@@ -142,13 +141,10 @@
 	role={open ? 'dialog' : undefined}
 	use:init={open}
 	use:focusTrap={open}
-	on:click={onButtonsClick}
->
+	on:click={onButtonsClick}>
 	<div class="relative p-4 w-full {sizes[size]} h-full md:h-auto">
 		<!-- Modal content -->
-		<div
-			class="relative bg-white rounded-lg shadow dark:bg-gray-700 text-gray-500 dark:text-gray-400"
-		>
+		<Frame rounded shadow class="relative">
 			<!-- Modal header -->
 			{#if $$slots.header || title}
 				<div class="flex justify-between items-center p-4 rounded-t border-b dark:border-gray-600">
@@ -168,12 +164,10 @@
 			</div>
 			<!-- Modal footer -->
 			{#if $$slots.footer}
-				<div
-					class="flex items-center p-6 space-x-2 rounded-b border-t border-gray-200 dark:border-gray-600"
-				>
+				<div class="flex items-center p-6 space-x-2 rounded-b border-t border-gray-200 dark:border-gray-600">
 					<slot name="footer" />
 				</div>
 			{/if}
-		</div>
+		</Frame>
 	</div>
 </div>

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -16,7 +16,6 @@
 </script>
 
 <Popper activeContent={true} {triggeredBy} {...$$restProps} class={popoverClass} on:show>
-	<slot name="trigger" slot="trigger" />
 	{#if $$slots.title || title}
 		<div
 			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">

--- a/src/lib/toasts/Toast.svelte
+++ b/src/lib/toasts/Toast.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Frame from '$lib/utils/Frame.svelte';
 	import classNames from 'classnames';
 	import * as transitions from 'svelte/transition';
 	import type { Colors, TransitionTypes, TransitionParamTypes } from '../types';
@@ -13,23 +14,7 @@
 	// Absolute position
 	export let position: 'tl' | 'tr' | 'bl' | 'br' = undefined; // default not set
 	export let visible = true;
-	export let divClass: string =
-		'w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800';
-
-	const colors = {
-		blue: 'text-blue-500 bg-blue-100 dark:bg-blue-800 dark:text-blue-200',
-		green: 'text-green-500 bg-green-100 dark:bg-green-800 dark:text-green-200',
-		red: 'text-red-500 bg-red-100 dark:bg-red-800 dark:text-red-200',
-		gray: 'text-gray-500 bg-gray-100 dark:bg-gray-800 dark:text-gray-200',
-		purple: 'text-purple-500 bg-purple-100 dark:bg-purple-800 dark:text-purple-200',
-		indigo: 'text-indigo-500 bg-indigo-100 dark:bg-indigo-800 dark:text-indigo-200',
-		yellow: 'text-yellow-500 bg-yellow-100 dark:bg-yellow-800 dark:text-yellow-200',
-		pink: 'text-pink-500 bg-pink-100 dark:bg-pink-800 dark:text-pink-200'
-	};
-
-	// have a custom transition function that returns the desired transition
-	let transitionFunc;
-	$: transitionFunc = transitions[transition] ?? transitions.fade;
+	export let divClass: string = 'w-full max-w-xs p-4';
 
 	$: classDiv = classNames(
 		divClass,
@@ -43,17 +28,14 @@
 	);
 
 	let iconClass;
-	$: iconClass = classNames(
-		'inline-flex items-center justify-center flex-shrink-0 rounded-lg w-8 h-8 mr-3',
-		colors[color]
-	);
+	$: iconClass = classNames('inline-flex items-center justify-center flex-shrink-0 w-8 h-8 mr-3');
 </script>
 
 {#if visible}
-	<div transition:transitionFunc={params} class={classDiv} role="alert">
+	<Frame rounded border {transition} {params} {...$$restProps} class={classDiv} role="alert">
 		<div class="flex {$$slots.extra ? 'items-start' : 'items-center'}">
 			{#if $$slots.icon}
-				<div class={iconClass}><slot name="icon" /></div>
+				<Frame {color} rounded class={iconClass}><slot name="icon" /></Frame>
 			{/if}
 
 			<div class="text-sm font-normal w-full">
@@ -64,5 +46,5 @@
 				<CloseButton on:click={() => (visible = false)} />
 			{/if}
 		</div>
-	</div>
+	</Frame>
 {/if}

--- a/src/lib/toasts/Toast.svelte
+++ b/src/lib/toasts/Toast.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
 	import Frame from '$lib/utils/Frame.svelte';
 	import classNames from 'classnames';
-	import * as transitions from 'svelte/transition';
-	import type { Colors, TransitionTypes, TransitionParamTypes } from '../types';
+	import type { Colors } from '../types';
 	import CloseButton from '../utils/CloseButton.svelte';
 
 	export let color: Colors = 'blue';
 	export let simple: boolean = false;
-	// Export a prop through which you can set a desired transition
-	export let transition: TransitionTypes = 'fade';
-	// Pass in extra transition params
-	export let params: TransitionParamTypes = {};
 	// Absolute position
 	export let position: 'tl' | 'tr' | 'bl' | 'br' = undefined; // default not set
 	export let visible = true;
@@ -32,7 +27,7 @@
 </script>
 
 {#if visible}
-	<Frame rounded border {transition} {params} {...$$restProps} class={classDiv} role="alert">
+	<Frame rounded border transition="fade" {...$$restProps} class={classDiv} role="alert">
 		<div class="flex {$$slots.extra ? 'items-start' : 'items-center'}">
 			{#if $$slots.icon}
 				<Frame {color} rounded class={iconClass}><slot name="icon" /></Frame>

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import classNames from 'classnames';
+	import { setContext } from 'svelte';
+	import { noop } from 'svelte/internal';
+	import * as transitions from 'svelte/transition';
+	import type { Colors, TransitionTypes, TransitionParamTypes } from '../types';
+
+	setContext('background', true);
+	$: setContext('color', color);
+
+	export let color: string = 'default';
+	export let rounded: boolean = false;
+	export let border: boolean = false;
+	export let shadow: boolean = false;
+
+	// Export a prop through which you can set a desired transition
+	export let transition: TransitionTypes | 'none' = 'none';
+	// Pass in extra transition params
+	export let params: TransitionParamTypes = {};
+
+	// your script goes here
+	const bgColors = {
+		gray: 'bg-gray-100 dark:bg-gray-200 ',
+		red: 'bg-red-100 dark:bg-red-200',
+		yellow: 'bg-yellow-100 dark:bg-yellow-200 ',
+		green: 'bg-green-100 dark:bg-green-200 ',
+		indigo: 'bg-indigo-100 dark:bg-indigo-200 ',
+		purple: 'bg-purple-100 dark:bg-purple-200 ',
+		pink: 'bg-pink-100 dark:bg-pink-200 ',
+		blue: 'bg-blue-100 dark:bg-blue-200 ',
+		light: 'bg-gray-50 dark:bg-gray-700',
+		dark: 'bg-gray-100 dark:bg-gray-700',
+		default: 'bg-white dark:bg-gray-800',
+		none: ''
+	};
+	const textColors = {
+		gray: 'text-gray-700 dark:text-gray-800',
+		red: 'text-red-700 dark:text-red-800',
+		yellow: 'text-yellow-700 dark:text-yellow-800',
+		green: 'text-green-700 dark:text-green-800',
+		indigo: 'text-indigo-700 dark:text-indigo-800',
+		purple: 'text-purple-700 dark:text-purple-800',
+		pink: 'text-pink-700 dark:text-pink-800',
+		blue: 'text-blue-700 dark:text-blue-800',
+		light: 'text-gray-700 dark:text-gray-300',
+		dark: 'text-gray-700 dark:text-gray-300',
+		default: 'text-gray-500 dark:text-gray-400',
+		none: ''
+	};
+
+	const borderColors = {
+		gray: 'border-gray-500 dark:bg-gray-200 ',
+		red: 'border-red-500 dark:bg-red-200 ',
+		yellow: 'border-yellow-500 dark:bg-tellow-200 ',
+		green: 'border-green-500 dark:bg-green-200 ',
+		indigo: 'border-indigo-500 dark:bg-indigo-200 ',
+		purple: 'border-purple-500 dark:bg-purple-200 ',
+		pink: 'border-pink-500 dark:bg-pink-200 ',
+		blue: 'border-blue-500 dark:bg-blue-200 ',
+		light: 'border-gray-500',
+		dark: 'border-gray-500',
+		default: 'border-gray-200 dark:border-gray-700',
+		none: ''
+	};
+
+	// have a custom transition function that returns the desired transition
+	let transitionFunc;
+	$: transitionFunc = transitions[transition] ?? noop;
+
+	let divClass: string;
+
+	$: divClass = classNames(
+		bgColors[color],
+		textColors[color],
+		rounded && 'rounded-lg ',
+		border && 'border',
+		borderColors[color],
+		shadow && 'shadow-md',
+		$$props.class
+	);
+</script>
+
+<div class={divClass} transition:transitionFunc={params}><slot /></div>

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import A from '$lib/typography/A.svelte';
 	import classNames from 'classnames';
 	import { setContext } from 'svelte';
 	import { noop } from 'svelte/internal';
@@ -8,6 +9,7 @@
 	setContext('background', true);
 	$: setContext('color', color);
 
+	export let tag: string = 'div';
 	export let color: string = 'default';
 	export let rounded: boolean = false;
 	export let border: boolean = false;
@@ -80,4 +82,6 @@
 	);
 </script>
 
-<div class={divClass} transition:transitionFunc={params}><slot /></div>
+<svelte:element this={tag} transition:transitionFunc={params} {...$$restProps} class={divClass}>
+	<slot />
+</svelte:element>

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import A from '$lib/typography/A.svelte';
 	import classNames from 'classnames';
 	import { setContext } from 'svelte';
-	import { noop } from 'svelte/internal';
 	import * as transitions from 'svelte/transition';
-	import type { Colors, TransitionTypes, TransitionParamTypes } from '../types';
+	import type { TransitionTypes, TransitionParamTypes } from '../types';
 
 	setContext('background', true);
 	$: setContext('color', color);
@@ -16,7 +14,7 @@
 	export let shadow: boolean = false;
 
 	// Export a prop through which you can set a desired transition
-	export let transition: TransitionTypes | 'none' = 'none';
+	export let transition: TransitionTypes = undefined;
 	// Pass in extra transition params
 	export let params: TransitionParamTypes = {};
 
@@ -67,7 +65,7 @@
 
 	// have a custom transition function that returns the desired transition
 	let transitionFunc;
-	$: transitionFunc = transitions[transition] ?? noop;
+	$: transitionFunc = transitions[transition];
 
 	let divClass: string;
 
@@ -82,6 +80,12 @@
 	);
 </script>
 
-<svelte:element this={tag} transition:transitionFunc={params} {...$$restProps} class={divClass}>
-	<slot />
-</svelte:element>
+{#if transitionFunc}
+	<svelte:element this={tag} transition:transitionFunc={params} {...$$restProps} class={divClass}>
+		<slot />
+	</svelte:element>
+{:else}
+	<svelte:element this={tag} {...$$restProps} class={divClass}>
+		<slot />
+	</svelte:element>
+{/if}

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -45,8 +45,7 @@
 
 	// typescript typeguards - poper.state.element.reference: Element|HTMLElement|VirtualElement
 	const hasHover = (el) => (el as Element).matches && (el as Element).matches(':hover');
-	const hasFocus = (el) =>
-		(el as Element).contains && (el as Element).contains(document.activeElement);
+	const hasFocus = (el) => (el as Element).contains && (el as Element).contains(document.activeElement);
 
 	const hideHandler = (ev) => {
 		if (activeContent) {

--- a/src/routes/toasts/+page.md
+++ b/src/routes/toasts/+page.md
@@ -6,7 +6,7 @@ layout: toastLayout
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
   import { Toast, Breadcrumb, BreadcrumbItem, Avatar, Button, A, Heading } from '$lib'
   import { quintOut, elasticOut } from 'svelte/easing';
-  
+
   import componentProps from '../props/Toast.json'
   // Props table
   let items = componentProps.props
@@ -388,7 +388,8 @@ Use this toast component to also show an “undo” button to reverse the action
 ```
 
 <Htwo label="Extra content" />
-Use the <span class="font-mono italic">slot="extra"</span> to add some more arbitrary content in the toast.
+
+Use the `slot="extra` to add some more arbitrary content in the toast.
 
 <h3 class='text-xl w-full dark:text-white py-4'>Toast message</h3>
 
@@ -397,7 +398,7 @@ This component can be used to show messages and a CTA button when receiveing cha
 <ExampleDiv>
   <Toast>
       <div class="flex" slot="extra">
-        <Avatar avatar={{src: '/images/profile-picture-1.webp', alt: 'My avatar 2', size: 12, round: true}}/>
+        <Avatar src='/images/profile-picture-1.webp' />
         <div class="ml-3 text-sm font-normal">
             <span class="mb-1 text-sm font-semibold text-gray-900 dark:text-white">Jese Leos</span>
             <div class="mb-2 text-sm font-normal">Hi Neil, thanks for sharing your thoughts regarding Flowbite.</div>
@@ -410,8 +411,7 @@ This component can be used to show messages and a CTA button when receiveing cha
 ```html
 <Toast>
 	<div class="flex" slot="extra">
-		<Avatar avatar={{src: '/images/profile-picture-1.webp', alt: 'My avatar 2', size: 12, round:
-		true}}/>
+    <Avatar src='/images/profile-picture-1.webp' />
 		<div class="ml-3 text-sm font-normal">
 			<span class="mb-1 text-sm font-semibold text-gray-900 dark:text-white">Jese Leos</span>
 			<div class="mb-2 text-sm font-normal">
@@ -431,7 +431,7 @@ This component can be used to show notifications for an action from another user
   <Toast>
     <span class="font-semibold text-gray-900 dark:text-white">New notification</span>
     <div class="flex items-center mt-3" slot="extra">
-      <Avatar avatar={{src: '/images/profile-picture-3.webp', alt: 'My avatar 2', size: 12, round: true}}/>
+      <Avatar src='/images/profile-picture-3.webp'/>
       <div class="ml-3">
         <h4 class="text-sm font-semibold text-gray-900 dark:text-white">Bonnie Green</h4>
         <div class="text-sm font-normal">commmented on your photo</div>
@@ -445,9 +445,8 @@ This component can be used to show notifications for an action from another user
 <Toast>
 	<span class="font-semibold text-gray-900 dark:text-white">New notification</span>
 	<div class="flex items-center mt-3" slot="extra">
-		<Avatar avatar={{src: '/images/profile-picture-3.webp', alt: 'My avatar 2', size: 12, round:
-		true}}/>
-		<div class="ml-3">
+    <Avatar src='/images/profile-picture-3.webp'/>
+    <div class="ml-3">
 			<h4 class="text-sm font-semibold text-gray-900 dark:text-white">Bonnie Green</h4>
 			<div class="text-sm font-normal">commmented on your photo</div>
 			<span class="text-xs font-medium text-blue-600 dark:text-blue-500">a few seconds ago</span>


### PR DESCRIPTION
## 📑 Description
Abstract component frame, base for `Alert, Toast, Dropdown, Card, Modal, GroupList`
- common colors of background and text
- common behaviour - disappearance
- common styling - borders, shadow, rounding
- as a side effect brings colors to `Dropdown`, `Card`, `List`
- no changes to any existing examples

### Custom colors treatment.
Current solution of introduction `customBgClass`, `customTextClass` is not really good as you can mix classes and set text classes to `customBgClass` attribute with the same result.

I have started to use 'none' as color to remove coloring classes and be free to add your custom classes in the standard `class` attribute.
```svelte
<Frame color="red" />

<Frame color="none" class"bg-yellow-100 text-red-500 />
```

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
