### PR TITLE
fix: programatic popper open merged

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -7,7 +7,6 @@
 	import ChevronRight from '../utils/ChevronRight.svelte';
 	import ChevronDown from '../utils/ChevronDown.svelte';
 	import ChevronLeft from '../utils/ChevronLeft.svelte';
-	import generateId from '$lib/utils/generateId';
 	import type { Placement } from '@popperjs/core';
 
 	export let label: string = '';
@@ -18,8 +17,6 @@
 	export let placement: 'auto' | Placement = 'bottom';
 	export let open: boolean = false;
 	export let triggeredBy: string = undefined;
-
-	let id = generateId();
 
 	const icons = {
 		top: ChevronUp,
@@ -37,7 +34,7 @@
 {#if label}
 	<slot name="trigger">
 		{#if inline}
-			<button {id} class={labelClass} class:flex-row-reverse={icon == ChevronLeft}>
+			<button class={labelClass} class:flex-row-reverse={icon == ChevronLeft}>
 				<slot name="label">{label}</slot>
 				{#if arrowIcon}
 					<svelte:component
@@ -46,7 +43,7 @@
 				{/if}
 			</button>
 		{:else}
-			<Button {id} {...$$restProps} class={icon == ChevronLeft && 'flex-row-reverse'}>
+			<Button {...$$restProps} class={icon == ChevronLeft && 'flex-row-reverse'}>
 				<slot name="label">{label}</slot>
 				{#if arrowIcon}
 					<svelte:component
@@ -58,14 +55,7 @@
 	</slot>
 {/if}
 
-<Popper
-	activeContent={true}
-	arrow={false}
-	{placement}
-	trigger="click"
-	on:show
-	bind:open
-	triggeredBy={triggeredBy ?? '#' + id}>
+<Popper activeContent={true} arrow={false} {placement} trigger="click" on:show bind:open {triggeredBy}>
 	<Frame class={popoverClass} rounded border shadow>
 		<slot name="content">
 			<ul class="py-1">

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
-	import Popper from '$lib/utils/Popper.svelte';
-	import classNames from 'classnames';
+  import Popper from '$lib/utils/Popper.svelte';
+  import classNames from 'classnames';
 
-	export let title: string = '';
-	export let triggeredBy: string;
+  export let title: string = '';
 
-	let popoverClass: string;
-	$: popoverClass = classNames(
-		'rounded-lg shadow-sm',
-		'bg-white dark:bg-gray-800',
-		'text-gray-500 dark:text-gray-400',
-		'border border-gray-200 dark:border-gray-700',
-		$$props.class
-	);
+  let popoverClass: string;
+  $: popoverClass = classNames(
+    'rounded-lg shadow-sm',
+    'bg-white dark:bg-gray-800',
+    'text-gray-500 dark:text-gray-400',
+    'border border-gray-200 dark:border-gray-700',
+    $$props.class
+  );
 </script>
 
-<Popper activeContent={true} {triggeredBy} {...$$restProps} class={popoverClass} on:show>
-	{#if $$slots.title || title}
-		<div
-			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
-			<slot name="title">
-				<h3 class="font-semibold text-gray-900 dark:text-white">{title}</h3>
-			</slot>
-		</div>
-	{/if}
-	<div class="py-2 px-3">
-		<slot />
-	</div>
+<Popper activeContent={true} {...$$restProps} class={popoverClass} on:show>
+  {#if $$slots.title || title}
+    <div
+      class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
+      <slot name="title">
+        <h3 class="font-semibold text-gray-900 dark:text-white">{title}</h3>
+      </slot>
+    </div>
+  {/if}
+  <div class="py-2 px-3">
+    <slot />
+  </div>
 </Popper>

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -32,7 +32,7 @@ layout: dropdownLayout
     alert ('Clicked.')
   }
 
-  let dropdownOpen = false;
+  let dropdownOpen = true;
 </script>
 
 <Breadcrumb class="pb-8">
@@ -147,7 +147,7 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
 <Dropdown label="Dropdown button" class="w-44">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-10 md:ml-16 w-44">
+    <Dropdown label="Dropdown" inline={true} placement="right-start" class="w-44">
     <DropdownItem>Overview</DropdownItem>
     <DropdownItem>My downloads</DropdownItem>
     <DropdownItem>Billing</DropdownItem>
@@ -163,7 +163,7 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
 <Dropdown label="Dropdown button" class="w-44">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-16 w-44">
+    <Dropdown label="Dropdown" inline={true} placement="right-start" class="w-44">
     <DropdownItem>Overview</DropdownItem>
     <DropdownItem>My downloads</DropdownItem>
     <DropdownItem>Billing</DropdownItem>


### PR DESCRIPTION
## 📑 Description
Fix for #256 

Popper can:
- be open/close programmatically
- be open at init
- be triggered by the previous sibling if no `triggeredBy` elements found

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

