### PR TITLE
feat: dropdown button

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -47,6 +47,7 @@
 	arrow={false}
 	{placement}
 	trigger="click"
+	{...$$restProps}
 	class={popoverClass}
 	on:show
 	bind:open>

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-	import Button from '$lib/buttons/Button.svelte';
-	import Frame from '$lib/utils/Frame.svelte';
-	import Popper from '$lib/utils/Popper.svelte';
 	import classNames from 'classnames';
-	import type { Placement } from '@popperjs/core';
+	import Button from '$lib/buttons/Button.svelte';
+	import Popper from '$lib/utils/Popper.svelte';
 	import Chevron from '$lib/utils/Chevron.svelte';
+	import type { Placement } from '@popperjs/core';
 
 	export let label: string = '';
 	export let inline: boolean = false;
 	export let arrowIcon: boolean = true;
 	export let labelClass: string =
 		'flex items-center justify-between w-full py-2 pl-3 pr-4 font-medium text-gray-700 border-b border-gray-100 hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-gray-400 dark:hover:text-white dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent';
-	export let placement: 'auto' | Placement = 'bottom';
+	export let placement: Placement = 'bottom';
 	export let open: boolean = false;
-	export let triggeredBy: string = undefined;
 
 	let popoverClass;
 	$: popoverClass = classNames('outline-none', $$props.class);
@@ -41,12 +39,20 @@
 	</slot>
 {/if}
 
-<Popper activeContent={true} arrow={false} {placement} trigger="click" on:show bind:open {triggeredBy}>
-	<Frame class={popoverClass} rounded border shadow>
-		<slot name="content">
-			<ul class="py-1">
-				<slot />
-			</ul>
-		</slot>
-	</Frame>
+<Popper
+	rounded
+	border
+	shadow
+	activeContent
+	arrow={false}
+	{placement}
+	trigger="click"
+	class={popoverClass}
+	on:show
+	bind:open>
+	<slot name="content">
+		<ul class="py-1">
+			<slot />
+		</ul>
+	</slot>
 </Popper>

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -3,11 +3,8 @@
 	import Frame from '$lib/utils/Frame.svelte';
 	import Popper from '$lib/utils/Popper.svelte';
 	import classNames from 'classnames';
-	import ChevronUp from '../utils/ChevronUp.svelte';
-	import ChevronRight from '../utils/ChevronRight.svelte';
-	import ChevronDown from '../utils/ChevronDown.svelte';
-	import ChevronLeft from '../utils/ChevronLeft.svelte';
 	import type { Placement } from '@popperjs/core';
+	import Chevron from '$lib/utils/Chevron.svelte';
 
 	export let label: string = '';
 	export let inline: boolean = false;
@@ -18,15 +15,6 @@
 	export let open: boolean = false;
 	export let triggeredBy: string = undefined;
 
-	const icons = {
-		top: ChevronUp,
-		right: ChevronRight,
-		bottom: ChevronDown,
-		left: ChevronLeft
-	};
-	// @ts-ignore
-	$: icon = icons[placement.split('-')[0]];
-
 	let popoverClass;
 	$: popoverClass = classNames('outline-none', $$props.class);
 </script>
@@ -34,21 +22,19 @@
 {#if label}
 	<slot name="trigger">
 		{#if inline}
-			<button class={labelClass} class:flex-row-reverse={icon == ChevronLeft}>
-				<slot name="label">{label}</slot>
+			<button class={labelClass}>
 				{#if arrowIcon}
-					<svelte:component
-						this={icon ?? ChevronDown}
-						class={classNames('h-4 w-4', icon == ChevronLeft ? 'mr-2' : 'ml-2')} />
+					<Chevron {placement}><slot name="label">{label}</slot></Chevron>
+				{:else}
+					<slot name="label">{label}</slot>
 				{/if}
 			</button>
 		{:else}
-			<Button {...$$restProps} class={icon == ChevronLeft && 'flex-row-reverse'}>
-				<slot name="label">{label}</slot>
+			<Button>
 				{#if arrowIcon}
-					<svelte:component
-						this={icon ?? ChevronDown}
-						class={classNames('h-4 w-4', icon == ChevronLeft ? 'mr-2' : 'ml-2')} />
+					<Chevron {placement}><slot name="label">{label}</slot></Chevron>
+				{:else}
+					<slot name="label">{label}</slot>
 				{/if}
 			</Button>
 		{/if}

--- a/src/lib/dropdowns/DropdownItem.svelte
+++ b/src/lib/dropdowns/DropdownItem.svelte
@@ -3,6 +3,7 @@
 	export let liClass: string =
 		'block font-medium cursor-pointer py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600';
 	export let color: string = 'default';
+	export let tabindex: number = 0;
 
 	const colors = {
 		default: 'text-gray-700 dark:text-gray-200 dark:hover:text-white',
@@ -21,7 +22,6 @@
 	on:blur
 	on:mouseenter
 	on:mouseleave
-	tabindex="0"
->
+	{tabindex}>
 	<slot />
 </li>

--- a/src/lib/navbar/NavLi.svelte
+++ b/src/lib/navbar/NavLi.svelte
@@ -12,7 +12,8 @@
 </script>
 
 <li>
-	<a
+	<svelte:element
+		this={href ? 'a' : 'div'}
 		{href}
 		{...$$restProps}
 		on:blur
@@ -25,8 +26,7 @@
 		on:mouseenter
 		on:mouseleave
 		on:mouseover
-		class={classNames(aClass, $$props.class)}
-	>
+		class={classNames(aClass, $$props.class)}>
 		<slot />
-	</a>
+	</svelte:element>
 </li>

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -1,29 +1,19 @@
 <script lang="ts">
-  import Popper from '$lib/utils/Popper.svelte';
-  import classNames from 'classnames';
+	import Popper from '$lib/utils/Popper.svelte';
 
-  export let title: string = '';
-
-  let popoverClass: string;
-  $: popoverClass = classNames(
-    'rounded-lg shadow-sm',
-    'bg-white dark:bg-gray-800',
-    'text-gray-500 dark:text-gray-400',
-    'border border-gray-200 dark:border-gray-700',
-    $$props.class
-  );
+	export let title: string = '';
 </script>
 
-<Popper activeContent={true} {...$$restProps} class={popoverClass} on:show>
-  {#if $$slots.title || title}
-    <div
-      class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
-      <slot name="title">
-        <h3 class="font-semibold text-gray-900 dark:text-white">{title}</h3>
-      </slot>
-    </div>
-  {/if}
-  <div class="py-2 px-3">
-    <slot />
-  </div>
+<Popper activeContent border shadow rounded {...$$restProps} class={$$props.clas} on:show>
+	{#if $$slots.title || title}
+		<div
+			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
+			<slot name="title">
+				<h3 class="font-semibold text-gray-900 dark:text-white">{title}</h3>
+			</slot>
+		</div>
+	{/if}
+	<div class="py-2 px-3">
+		<slot />
+	</div>
 </Popper>

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -2,9 +2,10 @@
 	import Popper from '$lib/utils/Popper.svelte';
 
 	export let title: string = '';
+	export let defaultClass: string = 'py-2 px-3';
 </script>
 
-<Popper activeContent border shadow rounded {...$$restProps} class={$$props.clas} on:show>
+<Popper activeContent border shadow rounded {...$$restProps} class={$$props.class} on:show>
 	{#if $$slots.title || title}
 		<div
 			class="py-2 px-3 bg-gray-100 rounded-t-lg border-b border-gray-200 dark:border-gray-600 dark:bg-gray-700">
@@ -13,7 +14,7 @@
 			</slot>
 		</div>
 	{/if}
-	<div class="py-2 px-3">
+	<div class={defaultClass}>
 		<slot />
 	</div>
 </Popper>

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -2,22 +2,27 @@
 	import Popper from '$lib/utils/Popper.svelte';
 	import classNames from 'classnames';
 
-	export let color: string = '';
-	export let style: 'dark' | 'light' | 'auto' | 'custom' = 'dark';
-	export let tipClass: string = 'py-2 px-3 text-sm font-medium rounded-lg shadow-sm tooltip';
-	export let triggeredBy: string;
+	export let color: string = 'custom';
+	export let style: 'dark' | 'light' | 'auto' | 'custom' = 'auto';
+	export let tipClass: string = 'py-2 px-3 text-sm font-medium';
 
 	const colors = {
-		dark: 'border border-gray-800 bg-gray-900 text-white dark:bg-gray-700 dark:border-gray-600',
-		light: 'border border-gray-200 bg-white text-gray-900',
-		auto: 'border border-gray-200 bg-white text-gray-900 dark:bg-gray-700 dark:text-white dark:border-gray-600 ',
-		custom: color
+		dark: 'border-gray-800 bg-gray-900 text-white dark:bg-gray-700 dark:border-gray-600',
+		light: 'border-gray-200 bg-white text-gray-900',
+		auto: 'border-gray-200 bg-white text-gray-900 dark:bg-gray-700 dark:text-white dark:border-gray-600 '
 	};
 
 	let toolTipClass;
 	$: toolTipClass = classNames(tipClass, colors[style], $$props.class);
 </script>
 
-<Popper activeContent={false} {triggeredBy} {...$$restProps} class={toolTipClass} on:show>
+<Popper
+	rounded
+	border
+	shadow
+	color={style === 'custom' ? color : 'none'}
+	{...$$restProps}
+	class={toolTipClass}
+	on:show>
 	<slot />
 </Popper>

--- a/src/lib/utils/Chevron.svelte
+++ b/src/lib/utils/Chevron.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { Placement } from '@popperjs/core';
+	import ChevronDown from './ChevronDown.svelte';
+	import ChevronLeft from './ChevronLeft.svelte';
+	import ChevronUp from './ChevronUp.svelte';
+	import ChevronRight from './ChevronRight.svelte';
+
+	export let placement: Placement = 'bottom';
+
+	const icons = {
+		top: ChevronUp,
+		right: ChevronRight,
+		bottom: ChevronDown,
+		left: ChevronLeft
+	};
+	// @ts-ignore
+	let icon;
+	$: icon = icons[placement.split('-')[0]] ?? ChevronDown;
+</script>
+
+{#if placement.split('-')[0] === 'left'}
+	<ChevronLeft class="h-4 w-4 mr-2" />
+	<slot />
+{:else}
+	<slot />
+	<svelte:component this={icon} class="h-4 w-4 ml-2" />
+{/if}

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import classNames from 'classnames';
 	import { setContext } from 'svelte';
-	import * as transitions from 'svelte/transition';
 
 	import { noop } from 'svelte/internal';
 	import type { Action } from 'svelte/action';
@@ -16,7 +15,7 @@
 	export let border: boolean = false;
 	export let shadow: boolean = false;
 
-	// Export a prop through which you can set a desired transition
+	// Export a prop through which you can set a desired svelte transition
 	export let transition: (node: Element, params: object) => TransitionConfig = undefined;
 	// Pass in extra transition params
 	export let params: object = {};

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -3,9 +3,9 @@
 	import { setContext } from 'svelte';
 	import * as transitions from 'svelte/transition';
 
-	import type { Action } from 'svelte/action';
-	import type { TransitionTypes, TransitionParamTypes } from '../types';
 	import { noop } from 'svelte/internal';
+	import type { Action } from 'svelte/action';
+	import type { TransitionConfig } from 'svelte/transition';
 
 	setContext('background', true);
 	$: setContext('color', color);
@@ -17,9 +17,9 @@
 	export let shadow: boolean = false;
 
 	// Export a prop through which you can set a desired transition
-	export let transition: TransitionTypes = undefined;
+	export let transition: (node: Element, params: object) => TransitionConfig = undefined;
 	// Pass in extra transition params
-	export let params: TransitionParamTypes = {};
+	export let params: object = {};
 
 	// For components development
 	export let node: HTMLElement = undefined;
@@ -73,7 +73,8 @@
 
 	// have a custom transition function that returns the desired transition
 	let transitionFunc;
-	$: transitionFunc = transitions[transition];
+	// $: transitionFunc = (node: Element) => (transition ? transition(node, params) : noop);
+	$: transitionFunc = transition ?? noop;
 
 	let divClass: string;
 
@@ -88,18 +89,16 @@
 	);
 </script>
 
-{#if transitionFunc}
-	<svelte:element
-		this={tag}
-		use:use={options}
-		bind:this={node}
-		transition:transitionFunc={params}
-		{...$$restProps}
-		class={divClass}>
-		<slot />
-	</svelte:element>
-{:else}
-	<svelte:element this={tag} use:use={options} bind:this={node} {...$$restProps} class={divClass}>
-		<slot />
-	</svelte:element>
-{/if}
+<svelte:element
+	this={tag}
+	use:use={options}
+	bind:this={node}
+	transition:transitionFunc={params}
+	{...$$restProps}
+	class={divClass}
+	on:mouseenter
+	on:mouseleave
+	on:focusin
+	on:focusout>
+	<slot />
+</svelte:element>

--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -2,12 +2,15 @@
 	import classNames from 'classnames';
 	import { setContext } from 'svelte';
 	import * as transitions from 'svelte/transition';
+
+	import type { Action } from 'svelte/action';
 	import type { TransitionTypes, TransitionParamTypes } from '../types';
+	import { noop } from 'svelte/internal';
 
 	setContext('background', true);
 	$: setContext('color', color);
 
-	export let tag: string = 'div';
+	export let tag: 'div' | 'a' = 'div';
 	export let color: string = 'default';
 	export let rounded: boolean = false;
 	export let border: boolean = false;
@@ -17,6 +20,11 @@
 	export let transition: TransitionTypes = undefined;
 	// Pass in extra transition params
 	export let params: TransitionParamTypes = {};
+
+	// For components development
+	export let node: HTMLElement = undefined;
+	export let use: Action = noop;
+	export let options = {};
 
 	// your script goes here
 	const bgColors = {
@@ -81,11 +89,17 @@
 </script>
 
 {#if transitionFunc}
-	<svelte:element this={tag} transition:transitionFunc={params} {...$$restProps} class={divClass}>
+	<svelte:element
+		this={tag}
+		use:use={options}
+		bind:this={node}
+		transition:transitionFunc={params}
+		{...$$restProps}
+		class={divClass}>
 		<slot />
 	</svelte:element>
 {:else}
-	<svelte:element this={tag} {...$$restProps} class={divClass}>
+	<svelte:element this={tag} use:use={options} bind:this={node} {...$$restProps} class={divClass}>
 		<slot />
 	</svelte:element>
 {/if}

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -5,6 +5,7 @@
 	import classNames from 'classnames';
 	import type { Placement, Instance } from '@popperjs/core';
 	import createEventDispatcher from './createEventDispatcher';
+	import Frame from './Frame.svelte';
 
 	export let activeContent: boolean = false;
 	export let animation: false | number = 100;
@@ -114,18 +115,19 @@
 {/if}
 
 {#if open && triggerEl}
-	<div
-		use:init={triggerEl}
-		transition:fade={{ duration: animation ? animation : 0 }}
+	<Frame
+		use={init}
+		options={triggerEl}
 		role="tooltip"
 		tabIndex={activeContent ? -1 : undefined}
-		class={classNames('z-10', $$props.class)}
 		on:focusin={activeContent ? showHandler : undefined}
 		on:focusout={activeContent ? hideHandler : undefined}
 		on:mouseenter={activeContent && !clickable ? showHandler : undefined}
 		on:mouseleave={activeContent && !clickable ? hideHandler : undefined}
+		{...$$restProps}
+		class={classNames('z-10', $$props.class)}
 		style="position: absolute;">
 		<slot />
 		{#if arrow}<div data-popper-arrow />{/if}
-	</div>
+	</Frame>
 {/if}

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -8,7 +8,6 @@
 	import Frame from './Frame.svelte';
 
 	export let activeContent: boolean = false;
-	export let animation: false | number = 100;
 	export let arrow: boolean = true;
 	export let offset: number = 8;
 	export let placement: Placement = 'top';
@@ -122,7 +121,7 @@
 		tabIndex={activeContent ? -1 : undefined}
 		on:focusin={activeContent ? showHandler : undefined}
 		on:focusout={activeContent ? hideHandler : undefined}
-		on:mouseenter={activeContent && !clickable ? showHandler : undefined}
+		on:mouseenter={showHandler}
 		on:mouseleave={activeContent && !clickable ? hideHandler : undefined}
 		{...$$restProps}
 		class={classNames('z-10', $$props.class)}

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -85,10 +85,11 @@
 			['mouseleave', hideHandler, !clickable]
 		];
 
-		triggerEls = [...document.querySelectorAll(triggeredBy)];
+		if (triggeredBy) triggerEls = [...document.querySelectorAll(triggeredBy)];
+		else triggerEls = contentEl.previousElementSibling ? [contentEl.previousElementSibling] : [];
+
 		if (!triggerEls.length) {
-			if (contentEl.previousElementSibling) triggerEls.push(contentEl.previousElementSibling);
-			else console.error('No triggers found.');
+			console.error('No triggers found.');
 		}
 
 		triggerEls.forEach((element: HTMLElement) => {

--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { fade } from 'svelte/transition';
 	import { createPopper } from '@popperjs/core';
 	import classNames from 'classnames';
 	import type { Placement, Instance } from '@popperjs/core';

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -6,7 +6,7 @@ layout: dropdownLayout
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
   import { Avatar, Button, Checkbox, Label, Helper, Dropdown, DropdownDivider, DropdownHeader, DropdownItem,
     Navbar,NavBrand,NavHamburger, NavUl, NavLi, Radio, Toggle, SimpleSearch, Breadcrumb, BreadcrumbItem, Badge, ToolbarButton, ChevronDown, Heading  } from '$lib'
-  
+  import Chevron from "$lib/utils/Chevron.svelte";
   import componentProps from '../props/Dropdown.json'
   import componentProps2 from '../props/DropdownDivider.json'
   import componentProps3 from '../props/DropdownHeader.json'
@@ -66,16 +66,18 @@ The dropdown component can be used to show a list of menu items when clicking on
 If you want to show a dropdown menu when clicking on an element add the `Dropdown` and `DropdownItem` components.
 
 <ExampleDiv class="flex justify-center items-start h-64">
-<Dropdown label="Dropdown button" class="w-44">
-  <DropdownItem>Dashboard</DropdownItem>
-  <DropdownItem>Settings</DropdownItem>
-  <DropdownItem>Earnings</DropdownItem>
-  <DropdownItem>Sign out</DropdownItem>
-</Dropdown>
+  <Button><Chevron>Dropdown button</Chevron></Button>
+  <Dropdown class="w-44">
+    <DropdownItem>Dashboard</DropdownItem>
+    <DropdownItem>Settings</DropdownItem>
+    <DropdownItem>Earnings</DropdownItem>
+    <DropdownItem>Sign out</DropdownItem>
+  </Dropdown>
 </ExampleDiv>
 
 ```html
-<Dropdown label="Dropdown button" class="w-44">
+<Button><Chevron>Dropdown button</Chevron></Button>
+<Dropdown class="w-44">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
@@ -146,13 +148,12 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
 <ExampleDiv class="flex justify-center items-start h-64">
 <Dropdown label="Dropdown button" class="w-44">
   <DropdownItem>Dashboard</DropdownItem>
-  <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="w-44">
+  <DropdownItem class="flex items-center justify-between"><Chevron placement="right">Dropdown</Chevron></DropdownItem>
+  <Dropdown placement="right-start" offset="100" class="w-44">
     <DropdownItem>Overview</DropdownItem>
     <DropdownItem>My downloads</DropdownItem>
     <DropdownItem>Billing</DropdownItem>
-    </Dropdown>
-  </DropdownItem>
+  </Dropdown>
   <DropdownItem>Earnings</DropdownItem>
   <DropdownDivider />
   <DropdownItem>Sign out</DropdownItem>
@@ -162,13 +163,12 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
 ```html
 <Dropdown label="Dropdown button" class="w-44">
   <DropdownItem>Dashboard</DropdownItem>
-  <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="w-44">
+  <DropdownItem class="flex items-center justify-between"><Chevron placement="right">Dropdown</Chevron></DropdownItem>
+  <Dropdown placement="right-start" class="w-44">
     <DropdownItem>Overview</DropdownItem>
     <DropdownItem>My downloads</DropdownItem>
     <DropdownItem>Billing</DropdownItem>
-    </Dropdown>
-  </DropdownItem>
+  </Dropdown>
   <DropdownItem>Earnings</DropdownItem>
   <DropdownDivider />
   <DropdownItem>Sign out</DropdownItem>
@@ -180,31 +180,31 @@ Use this example to enable multi-level dropdown menus by adding stacked elements
 When you want to control your dropdown open status via javascript code you can bind to `open` property.
 
 <ExampleDiv class="flex justify-center items-start h-64">
-<Dropdown label="Dropdown button" class="w-44" bind:open={dropdownOpen}>
-  <DropdownItem on:click={() => dropdownOpen = false}>Dashboard (close)</DropdownItem>
-  <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-10 md:ml-16 w-44">
-    <DropdownItem on:click={() => dropdownOpen = false}>Overview (close)</DropdownItem>
-    <DropdownItem>My downloads</DropdownItem>
-    <DropdownItem>Billing</DropdownItem>
+  <Button><Chevron>Dropdown button</Chevron></Button>
+  <Dropdown class="w-44" bind:open={dropdownOpen}>
+    <DropdownItem on:click={() => dropdownOpen = false}>Dashboard (close)</DropdownItem>
+    <DropdownItem class="flex items-center justify-between"><Chevron placement="right">Dropdown</Chevron></DropdownItem>
+    <Dropdown placement="right-start" class="w-44">
+      <DropdownItem on:click={() => dropdownOpen = false}>Overview (close)</DropdownItem>
+      <DropdownItem>My downloads</DropdownItem>
+      <DropdownItem>Billing</DropdownItem>
     </Dropdown>
-  </DropdownItem>
-  <DropdownItem>Earnings</DropdownItem>
-  <DropdownDivider />
-  <DropdownItem>Sign out</DropdownItem>
-</Dropdown>
+    <DropdownItem>Earnings</DropdownItem>
+    <DropdownDivider />
+    <DropdownItem>Sign out</DropdownItem>
+  </Dropdown>
 </ExampleDiv>
 
 ```html
-<Dropdown label="Dropdown button" class="w-44" bind:open={dropdownOpen}>
+<Button><Chevron>Dropdown button</Chevron></Button>
+<Dropdown class="w-44" bind:open={dropdownOpen}>
   <DropdownItem on:click={() => dropdownOpen = false}>Dashboard (close)</DropdownItem>
-  <DropdownItem>
-    <Dropdown label="Dropdown" inline={true} placement="right-start" class="ml-10 md:ml-16 w-44">
+  <DropdownItem class="flex items-center justify-between"><Chevron placement="right">Dropdown</Chevron></DropdownItem>
+  <Dropdown placement="right-start" class="w-44">
     <DropdownItem on:click={() => dropdownOpen = false}>Overview (close)</DropdownItem>
     <DropdownItem>My downloads</DropdownItem>
     <DropdownItem>Billing</DropdownItem>
-    </Dropdown>
-  </DropdownItem>
+  </Dropdown>
   <DropdownItem>Earnings</DropdownItem>
   <DropdownDivider />
   <DropdownItem>Sign out</DropdownItem>
@@ -217,13 +217,13 @@ Add multiple checkbox elements inside your dropdown menu to enable more advanced
 
 <ExampleDiv class="flex justify-center items-start h-52">
   <Dropdown label="Dropdown checkbox" class="w-44">
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Checkbox checked>Checked state</Checkbox>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
   </Dropdown>
@@ -235,13 +235,13 @@ Add multiple checkbox elements inside your dropdown menu to enable more advanced
   import { ..., ...., Checkbox } from 'flowbite-svelte'
 </script>
 <Dropdown label="Dropdown checkbox" class="w-44">
-  <DropdownItem>
+  <DropdownItem tabindex="-1">
     <Checkbox>Default checkbox</Checkbox>
   </DropdownItem>
-  <DropdownItem>
+  <DropdownItem tabindex="-1">
     <Checkbox checked>Checked state</Checkbox>
   </DropdownItem>
-  <DropdownItem>
+  <DropdownItem tabindex="-1">
     <Checkbox>Default checkbox</Checkbox>
   </DropdownItem>
 </Dropdown>
@@ -255,13 +255,13 @@ Use this example to update the background color of a menu item when using a list
 <ExampleDiv class="flex justify-center items-start h-56">
   <Dropdown label="Dropdown checkbox" class="w-48" >
     <ul slot="content" class="p-3 space-y-1">
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox>Default checkbox</Checkbox>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox checked>Checked state</Checkbox>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox>Default checkbox</Checkbox>
       </DropdownItem>
     </ul>
@@ -272,13 +272,13 @@ Use this example to update the background color of a menu item when using a list
 ```html
 <Dropdown label="Dropdown checkbox" class="w-48">
   <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox checked>Checked state</Checkbox>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox>Default checkbox</Checkbox>
     </DropdownItem>
   </ul>
@@ -294,15 +294,15 @@ Add an extra helper text to each checkbox element inside the dropdown menu list 
 <ExampleDiv class="flex justify-center items-start h-96">
   <Dropdown label="Dropdown checkbox" class="w-60" >
     <ul slot="content" class="p-3 space-y-1">
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox>Enable notifications</Checkbox>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox checked>Enable 2FA auth</Checkbox>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Checkbox>Subscribe newsletter</Checkbox>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
@@ -317,15 +317,15 @@ Add an extra helper text to each checkbox element inside the dropdown menu list 
 </script>
 <Dropdown label="Dropdown checkbox" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox>Enable notifications</Checkbox>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox checked>Enable 2FA auth</Checkbox>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Checkbox>Subscribe newsletter</Checkbox>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
@@ -339,13 +339,13 @@ Add multiple radio elements inside your dropdown menu to enable more advanced in
 
 <ExampleDiv class="flex justify-center items-start h-64">
   <Dropdown label="Dropdown radio" class="w-44">
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={1}>Default radio</Radio>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={2}>Checked state</Radio>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={3}>Default radio</Radio>
     </DropdownItem>
   </Dropdown>
@@ -359,13 +359,13 @@ Add multiple radio elements inside your dropdown menu to enable more advanced in
 </script>
 
 <Dropdown label="Dropdown radio" class="w-44">
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={1}>Default radio</Radio>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={2}>Checked state</Radio>
     </DropdownItem>
-    <DropdownItem>
+    <DropdownItem tabindex="-1">
       <Radio bind:group={group1} value={3}>Default radio</Radio>
     </DropdownItem>
 </Dropdown>
@@ -379,13 +379,13 @@ Use this example to update the background color of a menu item when using a list
 <ExampleDiv class="flex justify-center items-start h-64">
   <Dropdown label="Dropdown radio" class="w-48">
     <ul slot="content" class="p-3 space-y-1">
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group2} value={1}>Default radio</Radio>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group2} value={2}>Checked state</Radio>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group2} value={3}>Default radio</Radio>
       </DropdownItem>
     </ul>
@@ -400,13 +400,13 @@ Use this example to update the background color of a menu item when using a list
 
 <Dropdown label="Dropdown radio" class="w-48">
   <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group2} value={1}>Default radio</Radio>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group2} value={2}>Checked state</Radio>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group2} value={3}>Default radio</Radio>
     </DropdownItem>
   </ul>
@@ -422,15 +422,15 @@ Add an extra helper text to each radio element inside the dropdown menu list wit
 <ExampleDiv class="flex justify-center items-start h-96">
   <Dropdown label="Dropdown radio" class="w-60" trigger="hover">
     <ul slot="content" class="p-3 space-y-1">
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group3} value={1}>Enable notifications</Radio>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group3} value={2}>Enable 2FA auth</Radio>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
-      <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+      <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
         <Radio bind:group={group3} value={3}>Subscribe newsletter</Radio>
         <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
       </DropdownItem>
@@ -442,15 +442,15 @@ Add an extra helper text to each radio element inside the dropdown menu list wit
 ```html
 <Dropdown label="Dropdown radio" class="w-60" >
   <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={1}>Enable notifications</Radio>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={2}>Enable 2FA auth</Radio>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
-    <DropdownItem class="rounded" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
+    <DropdownItem class="rounded" tabindex="-1" liClass="p-2 hover:bg-gray-100 dark:hover:bg-gray-600">
       <Radio bind:group={group3} value={3}>Subscribe newsletter</Radio>
       <Helper class="pl-6">Some helpful instruction goes over here.</Helper>
     </DropdownItem>
@@ -465,13 +465,13 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 <ExampleDiv class="flex justify-center items-start h-64">
   <Dropdown label="Dropdown toggle" class="w-56">
   <ul slot="content" class="p-3 space-y-1">
-    <DropdownItem class="rounded">
+    <DropdownItem class="rounded" tabindex="-1">
       <Toggle>Default toggle</Toggle>
     </DropdownItem>
-    <DropdownItem class="rounded">
+    <DropdownItem class="rounded" tabindex="-1">
       <Toggle checked>Checked state</Toggle>
     </DropdownItem>
-    <DropdownItem class="rounded">
+    <DropdownItem class="rounded" tabindex="-1">
       <Toggle>Default toggle</Toggle>
     </DropdownItem>
   </ul>
@@ -485,13 +485,13 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 
 <Dropdown label="Dropdown radio" class="w-56">
 <ul slot="content" class="p-3 space-y-1">
-  <DropdownItem class="rounded">
+  <DropdownItem class="rounded" tabindex="-1">
     <Toggle>Default radio</Toggle>
   </DropdownItem>
-  <DropdownItem class="rounded">
+  <DropdownItem class="rounded" tabindex="-1">
     <Toggle checked>Checked state</Toggle>
   </DropdownItem>
-  <DropdownItem class="rounded">
+  <DropdownItem class="rounded" tabindex="-1">
     <Toggle>Default radio</Toggle>
   </DropdownItem>
 </ul>
@@ -517,21 +517,19 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 		<NavHamburger on:click={toggle} />
 		<NavUl {hidden}>
 			<NavLi href="/" active={true}>Home</NavLi>
-      <NavLi id="nav_dropdown">
-        <button class="flex items-center gap-1" on:click|preventDefault>Dropdown <ChevronDown size="14"/></button>
-      </NavLi>
+      <NavLi id="nav_dropdown" class="flex items-center"><Chevron>Dropdown</Chevron></NavLi>
 			<NavLi href="/services">Services</NavLi>
 			<NavLi href="/pricing">Pricing</NavLi>
 			<NavLi href="/contact">Contact</NavLi>
 		</NavUl>
 	</Navbar>
-      <Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open={false}>
-        <DropdownItem>Dashboard</DropdownItem>
-        <DropdownItem>Settings</DropdownItem>
-        <DropdownItem>Earnings</DropdownItem>
-        <DropdownDivider />
-        <DropdownItem>Sign out</DropdownItem>
-      </Dropdown>
+  <Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open>
+    <DropdownItem>Dashboard</DropdownItem>
+    <DropdownItem>Settings</DropdownItem>
+    <DropdownItem>Earnings</DropdownItem>
+    <DropdownDivider />
+    <DropdownItem>Sign out</DropdownItem>
+  </Dropdown>
 </ExampleDiv>
 
 ```html
@@ -552,18 +550,19 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
   <NavHamburger on:click={toggle} />
   <NavUl {hidden}>
     <NavLi href="/" active={true}>Home</NavLi>
-    <Dropdown label="Dropdown" placement="bottom-start" inline={true}>
-      <DropdownItem>Dashboard</DropdownItem>
-      <DropdownItem>Settings</DropdownItem>
-      <DropdownItem>Earnings</DropdownItem>
-      <DropdownDivider />
-      <DropdownItem>Sign out</DropdownItem>
-    </Dropdown>
+    <NavLi id="nav_dropdown" class="flex items-center"><Chevron>Dropdown</Chevron></NavLi>
     <NavLi href="/services">Services</NavLi>
     <NavLi href="/pricing">Pricing</NavLi>
     <NavLi href="/contact">Contact</NavLi>
   </NavUl>
 </Navbar>
+<Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open>
+  <DropdownItem>Dashboard</DropdownItem>
+  <DropdownItem>Settings</DropdownItem>
+  <DropdownItem>Earnings</DropdownItem>
+  <DropdownDivider />
+  <DropdownItem>Sign out</DropdownItem>
+</Dropdown>
 ```
 
 <Htwo label="Dropdown with scrolling" />

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -894,30 +894,20 @@ Use this example to also show the name or email of the user next to the avatar f
 <p>The dropdown menus work with buttons of all sizes including smaller or larger ones.</p>
 
 <ExampleDiv class="flex justify-center items-start gap-2 h-64">
-  <Button size="sm"><Chevron>Small dropdown</Chevron></Button>
-  <Dropdown>
+  <Dropdown >
     <DropdownItem>Dashboard</DropdownItem>
     <DropdownItem>Settings</DropdownItem>
     <DropdownItem>Earnings</DropdownItem>
     <DropdownItem>Sign out</DropdownItem>
   </Dropdown>
-  <Button size="lg"><Chevron>Large dropdown</Chevron></Button>
-  <Dropdown>
-    <DropdownItem>Dashboard</DropdownItem>
-    <DropdownItem>Settings</DropdownItem>
-    <DropdownItem>Earnings</DropdownItem>
-    <DropdownItem>Sign out</DropdownItem>
-  </Dropdown>
+  <Button class="sizes" size="sm"><Chevron>Small dropdown</Chevron></Button>
+  <Button class="sizes" size="lg"><Chevron>Large dropdown</Chevron></Button>
 </ExampleDiv>
 
 ```html
-<Dropdown label="Small dropdown" size="sm">
-  <DropdownItem>Dashboard</DropdownItem>
-  <DropdownItem>Settings</DropdownItem>
-  <DropdownItem>Earnings</DropdownItem>
-  <DropdownItem>Sign out</DropdownItem>
-</Dropdown>
-<Dropdown label="Large dropdown" size="lg">
+<Button class="sizes" size="sm"><Chevron>Small dropdown</Chevron></Button>
+<Button class="sizes" size="lg"><Chevron>Large dropdown</Chevron></Button>
+<Dropdown triggeredBy=".sizes">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -32,7 +32,7 @@ layout: dropdownLayout
     alert ('Clicked.')
   }
 
-  let dropdownOpen = true;
+  let dropdownOpen = false;
 </script>
 
 <Breadcrumb class="pb-8">

--- a/src/routes/dropdowns/+page.md
+++ b/src/routes/dropdowns/+page.md
@@ -4,7 +4,7 @@ layout: dropdownLayout
 
 <script>
   import { Htwo, ExampleDiv, GitHubSource, CompoDescription, TableProp, TableDefaultRow} from '../utils'
-  import { Avatar, Button, Checkbox, Label, Helper, Dropdown, DropdownDivider, DropdownHeader, DropdownItem,
+  import { Avatar, Button, Checkbox, Label, Helper, Dropdown, DropdownDivider, DropdownHeader, DropdownItem, Popover,
     Navbar,NavBrand,NavHamburger, NavUl, NavLi, Radio, Toggle, SimpleSearch, Breadcrumb, BreadcrumbItem, Badge, ToolbarButton, ChevronDown, Heading  } from '$lib'
   import Chevron from "$lib/utils/Chevron.svelte";
   import componentProps from '../props/Dropdown.json'
@@ -515,21 +515,21 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
 			</span>
 		</NavBrand>
 		<NavHamburger on:click={toggle} />
-		<NavUl {hidden}>
+		<NavUl {hidden} class="ml-3">
 			<NavLi href="/" active={true}>Home</NavLi>
       <NavLi id="nav_dropdown" class="flex items-center"><Chevron>Dropdown</Chevron></NavLi>
 			<NavLi href="/services">Services</NavLi>
 			<NavLi href="/pricing">Pricing</NavLi>
 			<NavLi href="/contact">Contact</NavLi>
 		</NavUl>
-	</Navbar>
-  <Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open>
+  <Dropdown placement="bottom" triggeredBy="#nav_dropdown" offset="18">
     <DropdownItem>Dashboard</DropdownItem>
     <DropdownItem>Settings</DropdownItem>
     <DropdownItem>Earnings</DropdownItem>
     <DropdownDivider />
     <DropdownItem>Sign out</DropdownItem>
   </Dropdown>
+	</Navbar>
 </ExampleDiv>
 
 ```html
@@ -548,21 +548,21 @@ Show a list of toggle switch elements inside the dropdown menu to enable a yes o
     </span>
   </NavBrand>
   <NavHamburger on:click={toggle} />
-  <NavUl {hidden}>
+  <NavUl {hidden} class="ml-3">
     <NavLi href="/" active={true}>Home</NavLi>
     <NavLi id="nav_dropdown" class="flex items-center"><Chevron>Dropdown</Chevron></NavLi>
     <NavLi href="/services">Services</NavLi>
     <NavLi href="/pricing">Pricing</NavLi>
     <NavLi href="/contact">Contact</NavLi>
   </NavUl>
-</Navbar>
-<Dropdown placement="bottom-start" triggeredBy="#nav_dropdown" open>
+<Dropdown placement="bottom" triggeredBy="#nav_dropdown" offset="18">
   <DropdownItem>Dashboard</DropdownItem>
   <DropdownItem>Settings</DropdownItem>
   <DropdownItem>Earnings</DropdownItem>
   <DropdownDivider />
   <DropdownItem>Sign out</DropdownItem>
 </Dropdown>
+</Navbar>
 ```
 
 <Htwo label="Dropdown with scrolling" />
@@ -894,13 +894,15 @@ Use this example to also show the name or email of the user next to the avatar f
 <p>The dropdown menus work with buttons of all sizes including smaller or larger ones.</p>
 
 <ExampleDiv class="flex justify-center items-start gap-2 h-64">
-  <Dropdown label="Small dropdown" size="sm">
+  <Button size="sm"><Chevron>Small dropdown</Chevron></Button>
+  <Dropdown>
     <DropdownItem>Dashboard</DropdownItem>
     <DropdownItem>Settings</DropdownItem>
     <DropdownItem>Earnings</DropdownItem>
     <DropdownItem>Sign out</DropdownItem>
   </Dropdown>
-  <Dropdown label="Large dropdown" size="lg">
+  <Button size="lg"><Chevron>Large dropdown</Chevron></Button>
+  <Dropdown>
     <DropdownItem>Dashboard</DropdownItem>
     <DropdownItem>Settings</DropdownItem>
     <DropdownItem>Earnings</DropdownItem>

--- a/src/routes/popover/+page.md
+++ b/src/routes/popover/+page.md
@@ -8,7 +8,7 @@ layout: modalLayout
   import { Popover, Avatar, Breadcrumb, BreadcrumbItem, Button, Input, Label, Checkbox, Heading } from '$lib'
   import  ChevronRight  from "$lib/utils/ChevronRight.svelte";
   import componentProps from '../props/Popover.json'
-
+  import { blur, fade, slide } from 'svelte/transition';
   let props = componentProps.props
   let propHeader = ['Name', 'Type', 'Default']
   let divClass='w-full relative overflow-x-auto shadow-md sm:rounded-lg py-4'
@@ -63,7 +63,7 @@ Make sure that you have the Flowbite JavaScript included in your project to enab
 Use this example to show more information about a user profile when hovering over the trigger component.
 
 <ExampleDiv class="flex h-72 items-end justify-center">
-  <Button  id="b2">User profile</Button>
+  <Button  id="b2" class="-mb-2">User profile</Button>
   <Popover triggeredBy="#b2" class="w-64 text-sm font-light text-gray-500 bg-white dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
     <div class="p-3">
         <div class="flex justify-between items-center mb-2">
@@ -124,6 +124,136 @@ Use this example to show more information about a user profile when hovering ove
               </a>
           </li>
       </ul>
+  </div>
+</Popover>
+```
+
+<Htwo label="Company profile" />
+
+This example can be used to show more information about a company profile.
+
+<ExampleDiv class="flex items-end justify-center h-96">
+<Button class="-mb-4">Company profile</Button>
+<Popover class="w-80 text-sm">  
+  <div class="flex">
+    <div class="mr-3 shrink-0">
+      <a href="/" class="block p-2 bg-gray-100 rounded-lg dark:bg-gray-700">
+        <img class="w-8 h-8 rounded-full" src="https://flowbite.com/docs/images/logo.svg" alt="Flowbite logo">
+      </a>
+    </div>
+    <div>
+      <p class="mb-1 text-base font-semibold leading-none text-gray-900 dark:text-white">
+          <a href="/" class="hover:underline">Flowbite</a>
+      </p>
+      <p class="mb-3 text-sm font-normal">Tech company</p>
+      <p class="mb-4 text-sm font-light">Open-source library of Tailwind CSS components and Figma design system.</p>
+      <ul class="text-sm font-light">
+        <li class="flex items-center mb-2">
+            <svg class="w-4 h-4 mr-1 font-semibold text-gray-400" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"></path></svg>
+            <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">https://flowbite.com/</a>
+        </li>
+        <li class="flex items-start mb-2">
+            <svg class="mr-1 w-6 font-semibold text-gray-400" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"></path></svg>
+            <span>4,567,346 people like this including 5 of your friends</span>
+        </li>
+      </ul>
+      <div class="flex mb-3 ml-4">
+        <Avatar src="/images/profile-picture-1.webp" stacked />
+        <Avatar src="/images/profile-picture-2.webp" stacked />
+        <Avatar src="/images/profile-picture-3.webp" stacked />
+        <Avatar stacked href="/" class="bg-gray-700 dark:bg-gray-700 text-white hover:bg-gray-600">+3</Avatar>
+      </div>
+      <div class="flex">
+        <Button color="alternative" class="mr-2 w-full">
+          <svg class="mr-2 w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"></path></svg>
+          Like page
+        </Button>
+        <Button color="alternative">
+          <svg class="w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"></path></svg>
+        </Button>
+      </div>
+    </div>
+  </div>
+</Popover>
+</ExampleDiv>
+
+```html
+<Button>Company profile</Button>
+<Popover class="w-80 text-sm">  
+  <div class="flex">
+    <div class="mr-3 shrink-0">
+      <a href="/" class="block p-2 bg-gray-100 rounded-lg dark:bg-gray-700">
+        <img class="w-8 h-8 rounded-full" src="https://flowbite.com/docs/images/logo.svg" alt="Flowbite logo">
+      </a>
+    </div>
+    <div>
+      <p class="mb-1 text-base font-semibold leading-none text-gray-900 dark:text-white">
+          <a href="/" class="hover:underline">Flowbite</a>
+      </p>
+      <p class="mb-3 text-sm font-normal">Tech company</p>
+      <p class="mb-4 text-sm font-light">Open-source library of Tailwind CSS components and Figma design system.</p>
+      <ul class="text-sm font-light">
+        <li class="flex items-center mb-2">
+            <svg class="w-4 h-4 mr-1 font-semibold text-gray-400" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"></path></svg>
+            <a href="/" class="text-blue-600 dark:text-blue-500 hover:underline">https://flowbite.com/</a>
+        </li>
+        <li class="flex items-start mb-2">
+            <svg class="mr-1 w-6 font-semibold text-gray-400" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"></path></svg>
+            <span>4,567,346 people like this including 5 of your friends</span>
+        </li>
+      </ul>
+      <div class="flex mb-3 ml-4">
+        <Avatar src="/images/profile-picture-1.webp" stacked />
+        <Avatar src="/images/profile-picture-2.webp" stacked />
+        <Avatar src="/images/profile-picture-3.webp" stacked />
+        <Avatar stacked href="/" class="bg-gray-700 dark:bg-gray-700 text-white hover:bg-gray-600">+3</Avatar>
+      </div>
+      <div class="flex">
+        <Button color="alternative" class="mr-2 w-full">
+          <svg class="mr-2 w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"></path></svg>
+          Like page
+        </Button>
+        <Button color="alternative">
+          <svg class="w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"></path></svg>
+        </Button>
+      </div>
+    </div>
+  </div>
+</Popover>
+```
+
+<Htwo label="Image popover" />
+
+Use this example to trigger a popover component with detailed information and an image when hovering over a portion of highlighted text inspired by Wikipedia and other large news outlets.
+
+<ExampleDiv class="flex items-end h-96">
+<p class="font-light text-gray-500 dark:text-gray-400">Due to its central geographic location in Southern Europe, <a href="/" class="text-blue-600 underline dark:text-blue-500 hover:no-underline" id="popover-image">Italy</a> has historically been home to myriad peoples and cultures. In addition to the various ancient peoples dispersed throughout what is now modern-day Italy, the most predominant being the Indo-European Italic peoples who gave the peninsula its name, beginning from the classical era, Phoenicians and Carthaginians founded colonies mostly in insular Italy</p>
+<Popover triggeredBy="#popover-image" class="w-96 text-sm font-light" defaultClass="">
+  <div class="grid grid-cols-5">
+    <div class="col-span-3 p-3">
+      <div class="space-y-2">
+        <h3 class="font-semibold text-gray-900 dark:text-white">About Italy</h3>
+        <p class="text-gray-500 dark:text-gray-500">Italy is located in the middle of the Mediterranean Sea, in Southern Europe it is also considered part of Western Europe. A unitary parliamentary republic with Rome as its capital and largest city.</p>
+        <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">Read more <svg class="ml-1 w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg></a>
+      </div>
+    </div>
+    <img src="/images/image-1.jpeg" class="col-span-2 h-full rounded-r-lg" alt="Italy map" />
+  </div>
+</Popover>
+</ExampleDiv>
+
+```html
+<p class="font-light text-gray-500 dark:text-gray-400">Due to its central geographic location in Southern Europe, <a href="/" class="text-blue-600 underline dark:text-blue-500 hover:no-underline" id="popover-image">Italy</a> has historically been home to myriad peoples and cultures. In addition to the various ancient peoples dispersed throughout what is now modern-day Italy, the most predominant being the Indo-European Italic peoples who gave the peninsula its name, beginning from the classical era, Phoenicians and Carthaginians founded colonies mostly in insular Italy</p>
+<Popover triggeredBy="#popover-image" class="w-96 text-sm font-light" defaultClass="">
+  <div class="grid grid-cols-5">
+    <div class="col-span-3 p-3">
+      <div class="space-y-2">
+        <h3 class="font-semibold text-gray-900 dark:text-white">About Italy</h3>
+        <p class="text-gray-500 dark:text-gray-400">Italy is located in the middle of the Mediterranean Sea, in Southern Europe it is also considered part of Western Europe. A unitary parliamentary republic with Rome as its capital and largest city.</p>
+        <a href="/" class="flex items-center font-medium text-blue-600 dark:text-blue-500 dark:hover:text-blue-600 hover:text-blue-700">Read more <svg class="ml-1 w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg></a>
+      </div>
+    </div>
+    <img src="/images/image-1.jpeg" class="col-span-2 h-full rounded-r-lg" alt="Italy map" />
   </div>
 </Popover>
 ```
@@ -345,6 +475,25 @@ Increase or decrease the default offset by adding the `offset` attribute where t
     And here's some amazing content. It's very engaging. Right?
 </Popover>
 ```
+
+<Htwo label="Animation" />
+
+Customize the animation of the popover component by using the transition functions from Svelte.
+
+<ExampleDiv  class="flex h-44 items-end justify-center gap-8">
+  <Button>Fade popover</Button>
+  <Popover class="w-64 text-sm font-light" title="Popover title" transition={fade} params={{duration: 700}}>
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+  <Button>Blur popover</Button>
+  <Popover class="w-64 text-sm font-light" title="Popover title" transition={blur} params={{duration: 500}}>
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+  <Button>Slide popover</Button>
+  <Popover class="w-64 text-sm font-light" title="Popover title" transition={slide}>
+      And here's some amazing content. It's very engaging. Right?
+  </Popover>
+</ExampleDiv>
 
 <Htwo label="Disable arrow" />
 

--- a/src/routes/tooltips/+page.md
+++ b/src/routes/tooltips/+page.md
@@ -28,7 +28,7 @@ layout: tooltipLayout
 <CompoDescription>Use the following Tailwind CSS powered tooltips to show extra content when hovering or focusing on an element</CompoDescription>
 
 <ExampleDiv>
-<GitHubSource href="tooltips/Tooltip.svelte">Tooltip</GitHubSource>
+  <GitHubSource href="tooltips/Tooltip.svelte">Tooltip</GitHubSource>
 </ExampleDiv>
 
 Flowbite-Svelte allows you to show extra information when hovering or focusing over an element in multiple positions, styles, and animations.
@@ -46,10 +46,8 @@ Flowbite-Svelte allows you to show extra information when hovering or focusing o
 To get started with using tooltips all you need to do is set `triggeredBy` attribute of the tooltip component to any CSS query targeting trigger element(s). In the following example you can see the tooltip that will be trigger by the `tooltip-default` element to be shown when hovered or focused.
 
 <ExampleDiv class="flex items-end gap-2 h-32">
-  <Button id="tooltip-default">Default tooltip</Button>
-  <Tooltip triggeredBy='#tooltip-default'>
-    Tooltip content
-  </Tooltip>
+  <Button>Default tooltip</Button>
+  <Tooltip>Tooltip content</Tooltip>
 </ExampleDiv>
 
 ```html
@@ -57,10 +55,8 @@ To get started with using tooltips all you need to do is set `triggeredBy` attri
   import {Tooltip, Button} from 'flowbite-svelte'
 </script>
 
-<Button id="tooltip-default">Default tooltip</Button>
-<Tooltip triggeredBy='#tooltip-default'>
-  Tooltip content
-</Tooltip>
+<Button>Default tooltip</Button>
+<Tooltip>Tooltip content</Tooltip>
 ```
 
 <Htwo label="Tooltip styles" />
@@ -71,18 +67,14 @@ You can use choose between dark and light version styles for the tooltip compone
   <Button id="style-light">Light tooltip</Button>
   <Button id="style-auto">Default tooltip</Button>
   <Button id="style-dark">Dark tooltip</Button>
-  <Tooltip style="light" triggeredBy="#style-light">Tooltip content</Tooltip>
-  <Tooltip style="auto" triggeredBy="#style-auto">Tooltip content</Tooltip>
-  <Tooltip style="dark" triggeredBy="#style-dark">Tooltip content</Tooltip>
+  <Tooltip {style} triggeredBy="[id^='style-']" on:show={ev => style = ev.target.id.split('-')[1]}>Tooltip content</Tooltip>
 </ExampleDiv>
 
 ```html
   <Button id="style-light">Light tooltip</Button>
   <Button id="style-auto">Default tooltip</Button>
   <Button id="style-dark">Dark tooltip</Button>
-  <Tooltip style="light" triggeredBy="#style-light">Tooltip content</Tooltip>
-  <Tooltip style="auto" triggeredBy="#style-auto">Tooltip content</Tooltip>
-  <Tooltip style="dark" triggeredBy="#style-dark">Tooltip content</Tooltip>
+  <Tooltip {style} triggeredBy="[id^='style-']" on:show={ev => style = ev.target.id.split('-')[1]}>Tooltip content</Tooltip>
 ```
 
 <Htwo label="Placement" />

--- a/src/routes/tooltips/+page.md
+++ b/src/routes/tooltips/+page.md
@@ -69,15 +69,19 @@ You can use choose between dark and light version styles for the tooltip compone
 
 <ExampleDiv class="flex items-end gap-2 h-32">
   <Button id="style-light">Light tooltip</Button>
+  <Button id="style-auto">Default tooltip</Button>
   <Button id="style-dark">Dark tooltip</Button>
   <Tooltip style="light" triggeredBy="#style-light">Tooltip content</Tooltip>
+  <Tooltip style="auto" triggeredBy="#style-auto">Tooltip content</Tooltip>
   <Tooltip style="dark" triggeredBy="#style-dark">Tooltip content</Tooltip>
 </ExampleDiv>
 
 ```html
   <Button id="style-light">Light tooltip</Button>
+  <Button id="style-auto">Default tooltip</Button>
   <Button id="style-dark">Dark tooltip</Button>
   <Tooltip style="light" triggeredBy="#style-light">Tooltip content</Tooltip>
+  <Tooltip style="auto" triggeredBy="#style-auto">Tooltip content</Tooltip>
   <Tooltip style="dark" triggeredBy="#style-dark">Tooltip content</Tooltip>
 ```
 
@@ -147,9 +151,10 @@ When you want to add custom styles, use `style="custom"`, `tipClass`, and `color
   <Tooltip
     triggeredBy="#custom"
 		placement="auto"
-		tipClass="rounded-lg p-24 text-lg font-medium shadow-sm text-white"
 		style="custom"
-		color="bg-red-900 dark:bg-red-700"
+    tipClass=""
+		class="p-24 text-lg font-medium text-white"
+    color='green'
 	>
 		Tooltip content
 	</Tooltip>


### PR DESCRIPTION
## 📑 Description
This is a first step towards separating the dropdown button from `Dropdown.svelte` component.

New component created in `utils`: `Chevron.svelte`, which contains the logic of attaching the appropriate chevron to text.
Examples of its usage are in `dropdowns` docs (first example, multi-level and navbar dropdown).

Separation of button from dropdown is in line with latest `Popper` changes, and gives a user the total control over the triggering component.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
I have left still the `label` option in `Dropdown.svelte` for the backward compatibility and until all examples are updated.
