### PR TITLE
wrong input path

### DIFF
--- a/src/routes/tabs/+page.md
+++ b/src/routes/tabs/+page.md
@@ -79,7 +79,7 @@ The tabs component can be used either as an extra navigational hierarchy complem
 
 ```html
 <script>
-	import { TabWrapper, TabHead, TabHeadItem, TabContentItem } from '$lib';
+	import { TabWrapper, TabHead, TabHeadItem, TabContentItem } from 'flowbite-svelte';
 	let activeTabValue = 1;
 	const handleClick = (tabValue) => () => {
 		activeTabValue = tabValue;


### PR DESCRIPTION
📑 Description
-  Setup was importing from $lib instead of 'flowbite-svelte'

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

