### PR TITLE
fix: use relative paths instead of $lib alias inside of lib

### DIFF
--- a/src/lib/alerts/Alert.svelte
+++ b/src/lib/alerts/Alert.svelte
@@ -2,7 +2,7 @@
   import classNames from 'classnames';
   import { createEventDispatcher } from 'svelte';
   import CloseButton from '../utils/CloseButton.svelte';
-  import Frame from '$lib/utils/Frame.svelte';
+  import Frame from '../utils/Frame.svelte';
 
   const dispatch = createEventDispatcher();
 

--- a/src/lib/avatar/Avatar.svelte
+++ b/src/lib/avatar/Avatar.svelte
@@ -3,7 +3,7 @@
 
 	import AvatarPlaceholder from './Placeholder.svelte';
 	import Dot from './Dot.svelte';
-	import type { DotType } from '$lib/types';
+	import type { DotType } from '../types';
 
 	export let src: string = '';
 	export let href: string = '#';

--- a/src/lib/cards/Card.svelte
+++ b/src/lib/cards/Card.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import classNames from 'classnames';
-	import Frame from '$lib/utils/Frame.svelte';
+	import Frame from '../utils/Frame.svelte';
 
 	export let href: string = undefined;
 	export let horizontal: boolean = false;

--- a/src/lib/drawer/Drawer.svelte
+++ b/src/lib/drawer/Drawer.svelte
@@ -2,7 +2,7 @@
   import classNames from 'classnames';
   import type { drawerTransitionParamTypes, drawerTransitionTypes } from '../types';
   import { fly, slide, blur, fade } from 'svelte/transition';
-  import { clickOutside } from '$lib/utils/clickOutside';
+  import { clickOutside } from '../utils/clickOutside';
 
   export let hidden: boolean = true;
   export let position: 'fixed' | 'absolute' = 'fixed';

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import classNames from 'classnames';
-	import Button from '$lib/buttons/Button.svelte';
-	import Popper from '$lib/utils/Popper.svelte';
-	import Chevron from '$lib/utils/Chevron.svelte';
+	import Button from '../buttons/Button.svelte';
+	import Popper from '../utils/Popper.svelte';
+	import Chevron from '../utils/Chevron.svelte';
 	import type { Placement } from '@popperjs/core';
 
 	export let label: string = '';

--- a/src/lib/forms/FloatingLabelInput.svelte
+++ b/src/lib/forms/FloatingLabelInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import classNames from 'classnames';
-	import generateId from '$lib/utils/generateId.js';
+	import generateId from '../utils/generateId.js';
 	import type { InputType } from '../types';
 
 	export let id: string = generateId();

--- a/src/lib/forms/Select.svelte
+++ b/src/lib/forms/Select.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import classNames from 'classnames';
-  import type { SelectOptionType } from '$lib/types';
+  import type { SelectOptionType } from '../types';
 
   export let items: SelectOptionType[] = [];
   export let value: string;

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import classNames from 'classnames';
 	import { getContext } from 'svelte';
-	import Wrapper from '$lib/utils/Wrapper.svelte';
+	import Wrapper from '../utils/Wrapper.svelte';
 
 	const background = getContext('background');
 

--- a/src/lib/list-group/Listgroup.svelte
+++ b/src/lib/list-group/Listgroup.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { setContext } from 'svelte';
   import classNames from 'classnames';
-  import type { ListGroupItemType } from '$lib/types';
+  import type { ListGroupItemType } from '../types';
   import ListgroupItem from './ListgroupItem.svelte';
-  import Frame from '$lib/utils/Frame.svelte';
+  import Frame from '../utils/Frame.svelte';
 
   export let items: ListGroupItemType[] = [];
   export let active: boolean = false;

--- a/src/lib/megamenu/MegaMenu.svelte
+++ b/src/lib/megamenu/MegaMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import classNames from 'classnames';
-	import type { LinkType } from '$lib/types';
-	import Popper from '$lib/utils/Popper.svelte';
+	import type { LinkType } from '../types';
+	import Popper from '../utils/Popper.svelte';
 
 	export let items: LinkTypeLike[] = [];
 	export let full: boolean = false;

--- a/src/lib/modals/Modal.svelte
+++ b/src/lib/modals/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Frame from '$lib/utils/Frame.svelte';
+	import Frame from '../utils/Frame.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import CloseButton from '../utils/CloseButton.svelte';
 	import focusTrap from '../utils/focusTrap';

--- a/src/lib/navbar/NavDropdown.svelte
+++ b/src/lib/navbar/NavDropdown.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { NavbarType } from '../types';
-	import { clickOutside } from '$lib/utils/clickOutside';
+	import { clickOutside } from '../utils/clickOutside';
 
 	export let liButtonClass: string = 'flex items-center justify-between w-full';
 	export let name: string;

--- a/src/lib/navbar/NavHamburger.svelte
+++ b/src/lib/navbar/NavHamburger.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ToolbarButton from '$lib/toolbar/ToolbarButton.svelte';
+	import ToolbarButton from '../toolbar/ToolbarButton.svelte';
 	import classNames from 'classnames';
 	import Menu from './Menu.svelte';
 

--- a/src/lib/navbar/NavUl.svelte
+++ b/src/lib/navbar/NavUl.svelte
@@ -2,7 +2,7 @@
 	import classNames from 'classnames';
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
-	import Frame from '$lib/utils/Frame.svelte';
+	import Frame from '../utils/Frame.svelte';
 
 	export let divClass: string = 'w-full md:block md:w-auto';
 	export let ulClass: string =

--- a/src/lib/navbar/Navbar.svelte
+++ b/src/lib/navbar/Navbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Frame from '$lib/utils/Frame.svelte';
+	import Frame from '../utils/Frame.svelte';
 	import classNames from 'classnames';
 
 	export let navClass: string = 'px-2 sm:px-4 py-2.5';

--- a/src/lib/popover/Popover.svelte
+++ b/src/lib/popover/Popover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Popper from '$lib/utils/Popper.svelte';
+	import Popper from '../utils/Popper.svelte';
 
 	export let title: string = '';
 	export let defaultClass: string = 'py-2 px-3';

--- a/src/lib/ratings/Review.svelte
+++ b/src/lib/ratings/Review.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { ReviewType } from '$lib/types';
+	import type { ReviewType } from '../types';
 	import classNames from 'classnames';
 	export let review: ReviewType;
 	export let articleClass: string = 'md:gap-8 md:grid md:grid-cols-3';

--- a/src/lib/toasts/Toast.svelte
+++ b/src/lib/toasts/Toast.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Frame from '$lib/utils/Frame.svelte';
+  import Frame from '../utils/Frame.svelte';
   import classNames from 'classnames';
   import type { Colors } from '../types';
   import CloseButton from '../utils/CloseButton.svelte';

--- a/src/lib/tooltips/Tooltip.svelte
+++ b/src/lib/tooltips/Tooltip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Popper from '$lib/utils/Popper.svelte';
+	import Popper from '../utils/Popper.svelte';
 	import classNames from 'classnames';
 
 	export let color: string = 'custom';


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #281

## 📑 Description
This changes the `$lib` references in the components (`src/lib/*`) to relative paths, which makes this library work without having to use SvelteKit. Future components should also use relative paths in order not to break the library for non-SvelteKit users.

More details in #281 

## ✅ Checks

- [✅] My pull request adheres to the code style of this project
- [❌] My code requires changes to the documentation
- [❌] I have updated the documentation as required **(not needed in this case)**
- [✅] All the tests have passed
- [✅] My pull request is based on the latest commit (not the npm version).

