### PR TITLE
fix(dropdown): add overflow-hidden

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -15,7 +15,7 @@
 	export let color: string = 'dropdown';
 
 	let popoverClass;
-	$: popoverClass = classNames('outline-none', $$props.class);
+	$: popoverClass = classNames('outline-none overflow-hidden', $$props.class);
 </script>
 
 {#if label}


### PR DESCRIPTION
Closes #296

## 📑 Description
Adds overflow-hidden as a default popoverClass to prevent the dropdown items from overflowing

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).