### PR TITLE
fix(DropdownItem): remove redundant part after else

### DIFF
--- a/src/lib/dropdowns/DropdownItem.svelte
+++ b/src/lib/dropdowns/DropdownItem.svelte
@@ -11,26 +11,20 @@
 	};
 </script>
 
-{#if href}
-	<li>
-		<svelte:element
-			this={href ? 'a' : 'div'}
-			{href}
-			{...$$restProps}
-			class={classNames(liClass, colors[color] ?? colors.default, $$props.class)}
-			on:click
-			on:change
-			on:keydown
-			on:keyup
-			on:focus
-			on:blur
-			on:mouseenter
-			on:mouseleave>
-			<slot />
-		</svelte:element>
-	</li>
-{:else}
-	<li class={classNames(liClass, colors[color] ?? colors.default, $$props.class)}>
+<li>
+	<svelte:element
+		this={href ? 'a' : 'div'}
+		{href}
+		{...$$restProps}
+		class={classNames(liClass, colors[color] ?? colors.default, $$props.class)}
+		on:click
+		on:change
+		on:keydown
+		on:keyup
+		on:focus
+		on:blur
+		on:mouseenter
+		on:mouseleave>
 		<slot />
-	</li>
-{/if}
+	</svelte:element>
+</li>


### PR DESCRIPTION
Closes #298 / #256

## 📑 Description
Events weren't forwarded from DropdownItem if the href attribute wasn't set.
I removed the `{#if href}` wrapped part as it seemed redundant, the only "backdraw" is that there will always be a div inside of the `<li>` tags, but I think that is alright. If not, I can revise this and just add the forwarded events directly to the li-element if no href is set

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
