### PR TITLE
Tab update

### DIFF
--- a/src/lib/tabs/TabHead.svelte
+++ b/src/lib/tabs/TabHead.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let tabStyle: 'default' | 'full' | 'icon' | 'pill' | 'underline' | 'custom';
+  export let tabStyle: 'default' | 'full' | 'icon' | 'pill' | 'underline' | 'custom' = 'default';
   export let customDivClass: string = '';
   export let customUlClass: string = '';
   type classOptions = {

--- a/src/lib/tabs/TabHeadItem.svelte
+++ b/src/lib/tabs/TabHeadItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import classNames from 'classnames';
   export let id: number;
-  export let tabStyle: string;
+  export let tabStyle: 'default' | 'full' | 'icon' | 'pill' | 'underline' | 'custom' = 'default';
   export let activeTabValue: number;
   export let customActiveClass: string = '';
   export let customInActiveClass: string = '';

--- a/src/lib/tabs/TabWrapper.svelte
+++ b/src/lib/tabs/TabWrapper.svelte
@@ -2,10 +2,8 @@
   import classNames from 'classnames';
   export let divClass: string = 'w-full';
   export let tabStyle: 'default' | 'full' | 'icon' | 'pill' | 'underline' | 'custom' = 'default';
-
-  export let activeTabValue: number;
 </script>
 
 <div class={classNames(divClass, $$props.class)}>
-  <slot {tabStyle} {activeTabValue} />
+  <slot {tabStyle} />
 </div>

--- a/src/routes/components/tab.md
+++ b/src/routes/components/tab.md
@@ -88,7 +88,7 @@ Use the following default tabs component example to show a list of links that th
 	};
 </script>
 
-<TabWrapper class="mb-4" activeTabValue let:tabStyle let:tabId>
+<TabWrapper class="mb-4" let:tabStyle>
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} {activeTabValue} on:click={handleClick(1)}>Profile</TabHeadItem>
 		<TabHeadItem id={2} {tabStyle} {activeTabValue} on:click={handleClick(2)}>Dashboard</TabHeadItem>
@@ -138,9 +138,8 @@ Use this alternative tabs component style with an underline instead of a backgro
 <TabWrapper
 	tabStyle="underline"
 	class="mb-4"
-	activeTabValue={activeTabValue2}
 	let:tabStyle
-	let:tabId>
+	>
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue2} on:click={handleClick2(1)}
 			>Profile</TabHeadItem>
@@ -195,9 +194,8 @@ Use icon components for a simple syntax. See <a href="/icons">Icons</a> for more
 <TabWrapper
 	tabStyle="icon"
 	class="mb-4"
-	activeTabValue={activeTabValue3}
 	let:tabStyle
-	let:tabId>
+	>
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue3} on:click={handleClick3(1)}
 			><svg
@@ -289,9 +287,8 @@ If you want to use pills as a style for the tabs component use `tabStyle="pill"`
 <TabWrapper
 	tabStyle="pill"
 	class="mb-4"
-	activeTabValue={activeTabValue4}
 	let:tabStyle
-	let:tabId>
+	>
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue4} on:click={handleClick4(1)}
 			>Profile</TabHeadItem>
@@ -345,9 +342,8 @@ If you want to show the tabs on the full width relative to the parent element us
 <TabWrapper
 	tabStyle="full"
 	class="mb-4"
-	activeTabValue={activeTabValue5}
 	let:tabStyle
-	let:tabId>
+	>
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue5} on:click={handleClick5(1)}
 			>Profile</TabHeadItem>
@@ -398,7 +394,7 @@ To disable a tab, add `disabled` to a `TabHeadItem`.
 	};
 </script>
 
-<TabWrapper class="mb-4" activeTabValue={activeTabValue6} let:tabStyle let:tabId>
+<TabWrapper class="mb-4" let:tabStyle >
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue6} on:click={handleClick6(1)}
 			>Profile</TabHeadItem>
@@ -457,7 +453,7 @@ You can add other components to the `TabContentItem` component. Here we are addi
 	};
 </script>
 
-<TabWrapper class="mb-4" activeTabValue={activeTabValue7} let:tabStyle let:tabId>
+<TabWrapper class="mb-4" let:tabStyle >
 	<TabHead {tabStyle}>
 		<TabHeadItem id={1} {tabStyle} activeTabValue={activeTabValue7} on:click={handleClick7(1)}
 			>Profile</TabHeadItem>

--- a/src/routes/components/tab.md
+++ b/src/routes/components/tab.md
@@ -88,12 +88,12 @@ Use the following default tabs component example to show a list of links that th
 	};
 </script>
 
-<TabWrapper class="mb-4" let:tabStyle>
-	<TabHead {tabStyle}>
-		<TabHeadItem id={1} {tabStyle} {activeTabValue} on:click={handleClick(1)}>Profile</TabHeadItem>
-		<TabHeadItem id={2} {tabStyle} {activeTabValue} on:click={handleClick(2)}>Dashboard</TabHeadItem>
-		<TabHeadItem id={3} {tabStyle} {activeTabValue} on:click={handleClick(3)}>Settings</TabHeadItem>
-		<TabHeadItem id={4} {tabStyle} {activeTabValue} on:click={handleClick(4)}>Users</TabHeadItem>
+<TabWrapper class="mb-4">
+	<TabHead>
+		<TabHeadItem id={1} {activeTabValue} on:click={handleClick(1)}>Profile</TabHeadItem>
+		<TabHeadItem id={2} {activeTabValue} on:click={handleClick(2)}>Dashboard</TabHeadItem>
+		<TabHeadItem id={3} {activeTabValue} on:click={handleClick(3)}>Settings</TabHeadItem>
+		<TabHeadItem id={4} {activeTabValue} on:click={handleClick(4)}>Users</TabHeadItem>
 	</TabHead>
 	<TabContentItem id={1} {activeTabValue}>
 		<p class="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
Tab component updates

* 1a6cfd32 (HEAD -> tab-update, origin/tab-update) fix: add default style to Ta
bHeadItem and TabHead and removed {tabStyle} from default example in tab page
* 5168c27c fix: remove activeTabvalue from TabWrapper and let:tabId vrom tab page examples

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

