### PR TITLE
fix: color flicker when changing theme using DarkMode

### DIFF
--- a/src/lib/darkmode/DarkMode.svelte
+++ b/src/lib/darkmode/DarkMode.svelte
@@ -1,37 +1,37 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	export let btnClass: string =
-		'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 fixed left-0 top-8 z-50';
-
-	let dark: boolean = false;
-
-	const toggleTheme = () => {
-		dark = window.document.documentElement.classList.toggle('dark');
-		localStorage.setItem('color-theme', dark ? 'dark' : 'light');
-	};
-
-	onMount(() => {
-		localStorage.getItem('color-theme') === 'dark' ||
-		(!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
-			? window.document.documentElement.classList.add('dark')
-			: window.document.documentElement.classList.remove('dark');
-
-		dark = window.document.documentElement.classList.contains('dark');
-	});
+  export let btnClass =
+    'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 fixed left-0 top-8 z-50';
+  let dark = false;
+  const toggleTheme = () => {
+    dark = window.document.documentElement.classList.toggle('dark');
+    localStorage.setItem('color-theme', dark ? 'dark' : 'light');
+  };
 </script>
 
+<svelte:head>
+  <script>
+    if (window) {
+      localStorage.getItem('color-theme') === 'dark' ||
+      (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        ? window.document.documentElement.classList.add('dark')
+        : window.document.documentElement.classList.remove('dark');
+    }
+  </script>
+</svelte:head>
+
 <button on:click={toggleTheme} aria-label="Dark mode" type="button" class={btnClass}>
-	{#if dark}
-		<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-			<path
-				d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-				fill-rule="evenodd"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	{:else}
-		<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-			<path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-		</svg>
-	{/if}
+  <div class="hidden dark:block">
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1
+  0 100-2H3a1 1 0 000 2h1z"
+        fill-rule="evenodd"
+        clip-rule="evenodd" />
+    </svg>
+  </div>
+  <div class="dark:hidden">
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  </div>
 </button>

--- a/src/lib/darkmode/DarkMode.svelte
+++ b/src/lib/darkmode/DarkMode.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  export let btnClass =
+  export let btnClass: string =
     'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 fixed left-0 top-8 z-50';
-  let dark = false;
   const toggleTheme = () => {
-    dark = window.document.documentElement.classList.toggle('dark');
-    localStorage.setItem('color-theme', dark ? 'dark' : 'light');
+    const isDark = window.document.documentElement.classList.toggle('dark');
+    localStorage.setItem('color-theme', isDark ? 'dark' : 'light');
   };
 </script>
 


### PR DESCRIPTION
## Using the DarkMode component I noticed that the theme colors were always flashing. The reason is the colors load before the onMount function sets the theme color.

See these videos, please:

### Before this patch:
https://user-images.githubusercontent.com/527641/193426844-53ca6292-998d-4304-8b59-48ee42140f78.mp4

### And after the patch:
https://user-images.githubusercontent.com/527641/193426955-4c22c110-a0b5-4d82-b015-5ae8dcf7df9e.mp4



## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->
- ✅ All the tests have passed
- ✅  My pull request is based on the latest commit (not the npm version).
