### PR TITLE
Fix Frame components delaying page dismount in Svelte-Kit.

### DIFF
--- a/src/lib/utils/Frame.svelte
+++ b/src/lib/utils/Frame.svelte
@@ -121,7 +121,7 @@
   this={tag}
   use:use={options}
   bind:this={node}
-  transition:transitionFunc={params}
+  transition:transitionFunc|local={params}
   {...$$restProps}
   class={divClass}
   on:mouseenter


### PR DESCRIPTION
## 📑 Description
At present any component (Card, Navbar, Accordion, etc) will delay page dismount when used with Svelte-Kit due to the presence of an unused transition component within `Frame.svelte`. This causes the page to which one is transitioning to appear underneath the current page, whilst the current page is still mounted. Both are therefore displayed simultaneously, and the dismounting of the current page seems to be delayed by about 500 milliseconds.

This can already be seen in the [docs](https://flowbite-svelte.com/components/accordion). Attempting to transition from the `Card` page to the `Alert` will cause the scrollbar on the side to expand before contracting (as the next page is mounted, and subsequently the current page is dismounted). If you scroll to the bottom of the page before the transition you can see the next page be mounted.

This behaviour is arguably a bug on Svelte's side as well, as the `transition` function used in `Frame.svelte` should be `undefined`, but it seems to be acting as though it has a default transition duration (thereby delaying dismounting as mentioned [here](https://github.com/sveltejs/svelte/issues/7620)).

Thankfully, this can be fixed by declaring the transition function as `local`, which causes the outgoing transition to *not* run when the page is dismounted. As far as I can tell, no current component uses this transition property anyway, so no difference in behaviour should be observed.

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch. 

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits. 

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information
I've confirmed this works on my local project, as it had rather short pages where the desync-ed dismounting of the current page was very noticable.

Also note that the `Accordion` page in the docs still displays the described behaviour, but it has separate transitions which would most likely need a similar fix.
