### PR TITLE
Allow value on Radio input to be a number

### DIFF
--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -42,7 +42,7 @@
   export let custom: boolean = false;
   export let inline: boolean = false;
   export let group: number | string = '';
-  export let value: string = '';
+  export let value: number | string = '';
 
   // tinted if put in component having its own background
   let background: boolean = getContext('background');


### PR DESCRIPTION
This PR allows the `value` to be a `number` and not restricted to `string`