### PR TITLE
fix: dropzone id and event handling

### DIFF
--- a/src/lib/forms/Dropzone.svelte
+++ b/src/lib/forms/Dropzone.svelte
@@ -5,21 +5,30 @@
   export let files: FileList | undefined = undefined;
   export let defaultClass: string =
     'flex flex-col justify-center items-center w-full h-64 bg-gray-50 rounded-lg border-2 border-gray-300 border-dashed cursor-pointer dark:hover:bg-bray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600';
+
+  let input: HTMLInputElement;
+
+  function keydown(ev: KeyboardEvent) {
+    if ([' ', 'Enter'].includes(ev.key)) {
+      ev.preventDefault();
+      input.click();
+    }
+  }
 </script>
 
-<label class={classNames(defaultClass, $$props.class)}>
+<label
+  class={classNames(defaultClass, $$props.class)}
+  tabIndex="0"
+  on:keydown={keydown}
+  on:focus
+  on:blur
+  on:mouseenter
+  on:mouseleave
+  on:mouseover
+  on:dragenter
+  on:dragleave
+  on:dragover
+  on:drop>
   <slot />
-  <input
-    {...$$restProps}
-    bind:value
-    bind:files
-    type="file"
-    class="hidden"
-    on:click
-    on:change
-    on:focus
-    on:blur
-    on:mouseenter
-    on:mouseleave
-    on:mouseover />
+  <input {...$$restProps} bind:value bind:files bind:this={input} type="file" class="hidden" on:change on:click />
 </label>


### PR DESCRIPTION
Closes #432

## 📑 Description
Dropzone is broken as hidden input has not have an id. 
I added an id to the hidden input and in the second commit I added a id prop as the example page shows that Dropzone gets passed an id.

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] I have updated the documentation as required (props gen)
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

