### PR TITLE
fix: og:image and twitter:image to replace spaces with -

### DIFF
--- a/src/routes/utils/MetaTag.svelte
+++ b/src/routes/utils/MetaTag.svelte
@@ -3,6 +3,11 @@
   export let breadcrumb_title: string = '';
   export let description: string = '';
   export let title: string = '';
+  // title = title.replaceAll(' ', '-');
+  let imgsrc = `https://open-graph-vercel.vercel.app/api/flowbite-svelte?title=${breadcrumb_title.replaceAll(
+    ' ',
+    '-'
+  )}`;
   export let dir: string = '';
   let dirstring = dir.toLowerCase();
   let breadcrumb = breadcrumb_title.toLowerCase().replaceAll(' ', '-');
@@ -22,7 +27,7 @@
     description: `${description}`,
     images: [
       {
-        url: `https://open-graph-vercel.vercel.app/api/flowbite-svelte?title=${breadcrumb_title}`,
+        url: imgsrc,
         width: 1200,
         height: 630,
         alt: `${title}`
@@ -35,6 +40,6 @@
     cardType: 'summary_large_image',
     title: `${title}`,
     description: `${description}`,
-    image: `https://open-graph-vercel.vercel.app/api/flowbite-svelte?title=${breadcrumb_title}`,
+    image: imgsrc,
     imageAlt: `${title}`
   }} />


### PR DESCRIPTION

## 📑 Description

- Twitter doesn't show og image where there are spaces
- Update MetaTag.svelte component

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

