### PR TITLE
add: Copy button to code block (ExampleWrapper)

### DIFF
--- a/src/routes/utils/ExampleWrapper.svelte
+++ b/src/routes/utils/ExampleWrapper.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import classNames from 'classnames';
+
+  import Button from '$lib/buttons/Button.svelte';
+
   export let divClass =
     'rounded-xl w-full my-4 mx-auto bg-gradient-to-r bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 p-2 sm:p-6';
 
@@ -9,8 +13,27 @@
   // all meta tags of the code block
   export let meta: any = undefined;
 
+  let browserSupport: boolean;
+  let code: HTMLElement;
+
   // suppress vite-plugin-svelte warning about unused props
   $: src, meta;
+
+  onMount(() => {
+    browserSupport = !!window?.navigator?.clipboard;
+  });
+
+  const copyToClipboard = async (e: MouseEvent) => {
+    const REG_HEX = /&#x([a-fA-F0-9]+);/g;
+    const decodedText = code.innerText.replace(REG_HEX, function (_match, group1) {
+      const num = parseInt(group1, 16);
+      return String.fromCharCode(num);
+    });
+
+    await window.navigator.clipboard.writeText(decodedText);
+
+    (e?.target as HTMLButtonElement)?.blur();
+  };
 
   function hack(node: HTMLElement) {
     node.parentElement?.classList.add('w-full');
@@ -20,6 +43,11 @@
 <div use:hack class={classNames(divClass, meta.class)}>
   <slot name="example" />
 </div>
-<div class="code">
-  <pre class="language-svelte"><slot name="code" /></pre>
+<div class="code relative">
+  {#if browserSupport}
+    <div class="absolute top-2 right-2 opacity-50 hover:opacity-100">
+      <Button on:click={(e) => copyToClipboard(e)} size="xs" color="alternative" pill={true}>Copy</Button>
+    </div>
+  {/if}
+  <pre bind:this={code} class="language-svelte"><slot name="code" /></pre>
 </div>


### PR DESCRIPTION
I really missed that feature so here we go :)
Closes #372

## 📑 Description
A copy button for code examples.
<img width="675" alt="Screen Shot 2022-11-23 at 20 56 44" src="https://user-images.githubusercontent.com/3374276/203552505-71e6da6f-5a2b-4e83-bac7-411731e5afa6.png">


## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


## ℹ Additional Information
I first wanted to go with the classic copy icon but did not want to import `svelte-heros-v2` just for this one feature. But lmk if there is a desire for *style* 😆 
