### PR TITLE
Revert "docs: fix Select example code"

### DIFF
--- a/src/routes/forms/select.md
+++ b/src/routes/forms/select.md
@@ -57,8 +57,9 @@ Get started with the default example of a select input component to get a single
   ]
 </script>
 
-<Label for="countries">Select an option</Label>
-<Select id="countries" class="mt-2" items={countries} bind:value={selected} />
+<Label>Select an option
+  <Select class="mt-2" items={countries} bind:value={selected} />
+</Label>
 ```
 
 <Htwo label="Disabled state" />


### PR DESCRIPTION
Reverts themesberg/flowbite-svelte#524

I disagree with that change. Using `<label for="...">` and embedding a form element inside the `label` is equivalent (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Label). This example was introduced like that on purpose to present both approaches.

Another point is that this PR introduce a bug, as now we have two selects with the same id, and that causes a strange focus behaviour.