### PR TITLE
docs: fix typo in carousel

### DIFF
--- a/src/routes/components/carousel.md
+++ b/src/routes/components/carousel.md
@@ -42,7 +42,7 @@ The carousel component can be used to cycle through a set of elements using cust
 ```html
 <script>
   import { Carousel, CarouselTransition } from 'flowbite-svelte'
-  // ./imageData/+server.js has the followint
+  // ./imageData/+server.js has the following
   export const images = [
   {
     id: 0,


### PR DESCRIPTION
## 📑 Description
This PR fixes a small typo in the `Carousel` documentation.

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
