### PR TITLE
Fix ListgroupItem Double Click Event

### DIFF
--- a/src/lib/list-group/ListgroupItem.svelte
+++ b/src/lib/list-group/ListgroupItem.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import { getContext } from 'svelte';
   import classNames from 'classnames';
-  import { createEventDispatcher } from 'svelte';
 
   export let active: boolean = getContext('active');
   export let current: boolean = false;
   export let disabled: boolean = false;
   export let href: string = '';
-
-  let dispatch = createEventDispatcher();
 
   const states = {
     current: 'text-white bg-blue-700 dark:text-white dark:bg-gray-800',
@@ -42,7 +39,6 @@
   <a
     {href}
     class="block {itemClass}"
-    on:click={() => dispatch('click', $$props)}
     aria-current={current}
     on:blur
     on:change
@@ -61,7 +57,6 @@
     type="button"
     class="inline-flex relative items-center text-left {itemClass}"
     {disabled}
-    on:click={() => dispatch('click', $$props)}
     on:blur
     on:change
     on:click


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #<!-- Issue # here -->

## 📑 Description
ListgroupItems are forwarding two click events, one through dispatch and one through a standard forwarded event. This PR removes the dispatched click event.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [X] All the tests have passed
- [X] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch. 

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits. 

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
