### PR TITLE
fix: align-items class removed from horizontal timelines

### DIFF
--- a/src/lib/timelines/Timeline.svelte
+++ b/src/lib/timelines/Timeline.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
-	export let customClass: string = '';
-	export let order: 'default' | 'vertical' | 'horizontal' | 'activity' | 'group' | 'custom' =
-		'default';
+  import { setContext } from 'svelte';
+  export let customClass: string = '';
+  export let order: 'default' | 'vertical' | 'horizontal' | 'activity' | 'group' | 'custom' = 'default';
 
-	setContext('order', order);
-	let olClasses = {
-		group:
-			'p-5 mb-4 bg-gray-50 rounded-lg border border-gray-100 dark:bg-gray-800 dark:border-gray-700',
-		horizontal: 'items-center sm:flex',
-		activity: 'relative border-l border-gray-200 dark:border-gray-700',
-		vertical: 'relative border-l border-gray-200 dark:border-gray-700',
-		default: 'relative border-l border-gray-200 dark:border-gray-700',
-		custom: customClass
-	};
+  setContext('order', order);
+  let olClasses = {
+    group: 'p-5 mb-4 bg-gray-50 rounded-lg border border-gray-100 dark:bg-gray-800 dark:border-gray-700',
+    horizontal: 'sm:flex',
+    activity: 'relative border-l border-gray-200 dark:border-gray-700',
+    vertical: 'relative border-l border-gray-200 dark:border-gray-700',
+    default: 'relative border-l border-gray-200 dark:border-gray-700',
+    custom: customClass
+  };
 </script>
 
 <ol class={olClasses[order]}>
-	<slot />
+  <slot />
 </ol>

--- a/src/lib/timelines/TimelineHorizontal.svelte
+++ b/src/lib/timelines/TimelineHorizontal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	export let olClass: string = 'items-center sm:flex';
+  export let olClass: string = 'sm:flex';
 </script>
 
 <ol class={olClass}>
-	<slot />
+  <slot />
 </ol>


### PR DESCRIPTION
Closes #606

## 📑 Description
Removes items-center class on horizontal timelines

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
