### PR TITLE
docs(footer): fix wrapping and spacings on mobile devices

### DIFF
--- a/src/routes/utils/CopyCliboardInput.svelte
+++ b/src/routes/utils/CopyCliboardInput.svelte
@@ -34,7 +34,7 @@
   };
 </script>
 
-<Input size="lg" {placeholder} readonly class="!text-sm md:min-w-[255px] {$$props.class ?? ''}">
+<Input size="lg" {placeholder} readonly class="!text-sm focus:ring-primary-600 focus:border-primary-600 md:min-w-[255px] {$$props.class ?? ''}">
   <div slot="right" class="flex items-center pl-32">
     <button on:click={copyToClipboard} class="hover:text-primary-700 py-2 px-1">
       {#if tooltip_text == text_not_copied}<Clipboard />{:else}<Check />{/if}

--- a/src/routes/utils/Footer.svelte
+++ b/src/routes/utils/Footer.svelte
@@ -32,7 +32,7 @@
 <Footer footerType="custom" customClass="bg-white dark:bg-gray-900">
   <div class="flex flex-col py-6 lg:py-12 mx-auto max-w-8xl">
     <div class="flex flex-col lg:flex-row items-start md:justify-between gap-8 {isHomePage ? 'px-4 lg:px-20' : ''}">
-      <div class="mb-6 md:mb-0 w-full max-w-sm">
+      <div class="w-full max-w-sm">
         <FooterBrand
           href="https://flowbite-svelte.com"
           src={logo}
@@ -54,7 +54,7 @@
           >.
         </p>
       </div>
-      <div class="flex flex-col md:flex-row items-start {isHomePage ? 'gap-16 lg:justify-end' : 'gap-8'}  w-full">
+      <div class="flex flex-col md:flex-row items-start {isHomePage ? 'gap-4 md:gap-16 lg:justify-end' : 'gap-8'}  w-full">
         {#each Object.entries(footer_links) as [column, links]}
           <div>
             <h2 class="mb-6 text-sm font-semibold text-gray-900 uppercase dark:text-white">{column}</h2>

--- a/src/routes/utils/Footer.svelte
+++ b/src/routes/utils/Footer.svelte
@@ -68,7 +68,7 @@
       </div>
     </div>
     <hr class="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
-    <div class="sm:flex sm:items-center sm:justify-center">
+    <div class="flex items-center justify-center px-4 text-center">
       <FooterCopyright
         href="/"
         by="Flowbite™"

--- a/src/routes/utils/Footer.svelte
+++ b/src/routes/utils/Footer.svelte
@@ -48,8 +48,7 @@
           <a
             href="https://github.com/themesberg/flowbite-svelte/blob/main/LICENSE"
             class="text-primary-600 hover:underline">
-            MIT
-          </a>, docs
+            MIT</a>, docs
           <a href="https://creativecommons.org/licenses/by/3.0/" class="text-primary-600 hover:underline"
             >CC BY 3.0</a
           >.

--- a/src/routes/utils/Newsletter.svelte
+++ b/src/routes/utils/Newsletter.svelte
@@ -47,7 +47,7 @@
               <Input
                 size="lg"
                 id="member_email"
-                class="formkit-input text-gray-900 pl-12 sm:!w-96"
+                class="formkit-input text-gray-900 pl-12 sm:!w-96 focus:ring-primary-600 focus:border-primary-600"
                 name="email_address"
                 aria-label="Email Address"
                 placeholder="Your email address..."


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/themesberg/flowbite-svelte/issues/698

## 📑 Description

This PR improves text wrapping and spacings on mobile devices.

Before:

<img width="500" alt="Screenshot 2023-04-25 at 12 06 20" src="https://user-images.githubusercontent.com/8052108/234230557-24f37fad-7a51-4d8f-9742-376c9c358e5d.png">

After:

<img width="496" alt="Screenshot 2023-04-25 at 12 11 05" src="https://user-images.githubusercontent.com/8052108/234230586-68de65f9-c581-46d1-b5ad-ac1de96262d9.png">

- [ ] Not Completed
- [x] Completed

## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).