### PR TITLE
accordion optional props

### DIFF
--- a/src/lib/accordion/Accordion.svelte
+++ b/src/lib/accordion/Accordion.svelte
@@ -15,11 +15,11 @@
   import { setContext, type ComponentProps } from 'svelte';
 
   interface $$Props extends ComponentProps<Frame> {
-    multiple: boolean;
-    flush: boolean;
-    activeClasses: string;
-    inactiveClasses: string;
-    defaultClass: string;
+    multiple?: boolean;
+    flush?: boolean;
+    activeClasses?: string;
+    inactiveClasses?: string;
+    defaultClass?: string;
   }
 
   export let multiple: boolean = false;


### PR DESCRIPTION
Closes #768 

## 📑 Description
Since all the Accordion props have default values them should be optional in type descryptor.

## Status

- [] Not Completed
- [x] Completed


## ✅ Checks
<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
