### PR TITLE
Make `Checkbox` behavior consistent with HTML defaults

### DIFF
--- a/src/lib/forms/Checkbox.svelte
+++ b/src/lib/forms/Checkbox.svelte
@@ -10,7 +10,7 @@
   export let inline: boolean = false;
 
   export let group: (string | number)[] = [];
-  export let value: string | number = '';
+  export let value: string | number = 'on';
   export let checked: boolean | undefined = undefined;
 
   // tinted if put in component having its own background

--- a/src/routes/testdir/checkbox/+page.server.ts
+++ b/src/routes/testdir/checkbox/+page.server.ts
@@ -1,0 +1,7 @@
+import type { Actions } from '@sveltejs/kit';
+
+export const actions: Actions = {
+	default: async ({ request }) => {
+		console.log(await request.formData());
+	}
+};

--- a/src/routes/testdir/checkbox/+page.svelte
+++ b/src/routes/testdir/checkbox/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { Label, Checkbox, Button, Kbd } from 'flowbite-svelte';
+</script>
+
+<form method="post" class="space-y-4 p-4">
+	<label class="block">
+		<input type="checkbox" name="html-value-set" value="hello" checked />
+		<span>HTML checkbox without value</span>
+	</label>
+	<label class="block">
+		<input type="checkbox" name="html-value-not-set" checked />
+		<span>HTML checkbox without value</span>
+	</label>
+	<hr />
+	<Label>
+		<Checkbox name="flowbite-value-set" value="hello" checked />
+		<span>Flowbite checkbox with <Kbd>"Value"</Kbd> set</span>
+	</Label>
+	<Label>
+		<Checkbox name="flowbite-value-not-set" checked />
+		<span>Flowbite checkbox with <Kbd>"Value"</Kbd> not set</span>
+	</Label>
+	<hr />
+	<Button type="submit">Submit</Button>
+</form>


### PR DESCRIPTION
Closes #794

## 📑 Description

Adds a default value to `Checkbox` component `value` prop, in order to comply with default HTML behavior.
Probably there's a cleaner solution (cause the value in html checkbox is added only on submission, and not from before) – but it's a try.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
