### PR TITLE
Added touchevent forwarding to Buttons

### DIFF
--- a/src/lib/buttons/Button.svelte
+++ b/src/lib/buttons/Button.svelte
@@ -126,6 +126,9 @@
   on:change
   on:keydown
   on:keyup
+  on:touchstart
+  on:touchend
+  on:touchcancel
   on:mouseenter
   on:mouseleave>
   <slot />

--- a/src/lib/buttons/Button.svelte
+++ b/src/lib/buttons/Button.svelte
@@ -167,6 +167,9 @@
   - on:change
   - on:keydown
   - on:keyup
+  - on:touchstart
+  - on:touchend
+  - on:touchcancel
   - on:mouseenter
   - on:mouseleave
   ## Example

--- a/src/lib/buttons/GradientButton.svelte
+++ b/src/lib/buttons/GradientButton.svelte
@@ -110,6 +110,9 @@
   - on:change
   - on:keydown
   - on:keyup
+  - on:touchstart
+  - on:touchend
+  - on:touchcancel
   - on:mouseenter
   - on:mouseleave
   ## Example

--- a/src/routes/docs/components/button.md
+++ b/src/routes/docs/components/button.md
@@ -13,7 +13,7 @@ thumnailSize: w-24
   import { Badge, P, A } from '$lib'
   import { props as buttonProps } from '../../props/Button.json'
 
-  const events = ["on:change","on:click","on:keydown","on:keyup","on:mouseenter","on:mouseleave"];
+  const events = ["on:change","on:click","on:keydown","on:keyup","on:mouseenter","on:mouseleave","on:touchstart","on:touchend","on:touchcancel"];
   // slots
   let slotHeader = ['Name', 'Description']
   let slotItems = [['default', 'For a button label.']]

--- a/src/routes/docs/components/button.md
+++ b/src/routes/docs/components/button.md
@@ -272,11 +272,11 @@ You can use on:click or any standard on:* to listen to the event.
     alert('You clicked btn1.');
   };
   const btn2 = () => {
-    alert('You clicked btn2.');
+    alert('You touched btn2.');
   };
 </script>
 <Button on:click={btn1}>Button 1</Button>
-<Button on:click={btn2}>Button 2</Button>
+<Button on:touchstart={btn2}>Button 2</Button>
 ```
 
 ## Props


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

I noticed that the Button components do not forward the touchevents. However, these are essential for mobile development. So I added them to the list of forwarded events.

## Status

- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

