### PR TITLE
fix: transitions in drawer

### DIFF
--- a/src/lib/drawer/Drawer.svelte
+++ b/src/lib/drawer/Drawer.svelte
@@ -50,6 +50,10 @@
     backdrop && bgColor,
     backdrop && bgOpacity
   );
+
+  function clickOutsideWrapper(node: HTMLElement, callback: () => void) {
+    return activateClickOutside ? clickOutside(node, callback) : undefined;
+  }
 </script>
 
 {#if !hidden}
@@ -58,30 +62,18 @@
   {:else if backdrop && !activateClickOutside}
     <div role="presentation" class={backdropDivClass} />
   {/if}
-  {#if activateClickOutside}
-    <div
-      use:clickOutside={() => !hidden && handleDrawer()}
-      {id}
-      {...$$restProps}
-      class={twMerge(divClass, width, position, placements[placement], $$props.class)}
-      transition:multiple={transitionParams}
-      tabindex="-1"
-      aria-controls={id}
-      aria-labelledby={id}>
-      <slot {hidden} />
-    </div>
-  {:else}
-    <div
-      {id}
-      {...$$restProps}
-      class={twMerge(divClass, width, position, placements[placement], $$props.class)}
-      transition:multiple={transitionParams}
-      tabindex="-1"
-      aria-controls={id}
-      aria-labelledby={id}>
-      <slot {hidden} />
-    </div>
-  {/if}
+
+  <div
+    use:clickOutsideWrapper={() => !hidden && handleDrawer()}
+    {id}
+    {...$$restProps}
+    class={twMerge(divClass, width, position, placements[placement], $$props.class)}
+    transition:multiple={transitionParams}
+    tabindex="-1"
+    aria-controls={id}
+    aria-labelledby={id}>
+    <slot {hidden} />
+  </div>
 {/if}
 
 <!--


### PR DESCRIPTION
## 📑 Description

Fix to `Drawer` transitions.

With the move to Svelte 4 transitions became local by default. Drawer had a nested `if`s structure so local transitions stopped to work.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
