### PR TITLE
fix: add shrink-0 to prevent toggle UI from shrinking on small screen sizes

### DIFF
--- a/src/lib/forms/Toggle.svelte
+++ b/src/lib/forms/Toggle.svelte
@@ -14,7 +14,7 @@
   let background: boolean = getContext('background');
 
   const common =
-    "mr-3 bg-gray-200 rounded-full peer-focus:ring-4 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all";
+    "mr-3 shrink-0 bg-gray-200 rounded-full peer-focus:ring-4 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all";
 
   const colors = {
     primary: 'peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 peer-checked:bg-primary-600',


### PR DESCRIPTION
## 📑 Description

Currently on small device sizes the toggle shrinks and clips. This PR resolves this by adding `shrink-0`.

### Video showing current issue

https://github.com/themesberg/flowbite-svelte/assets/8170676/deb3c691-cbe9-4447-9f8a-c50e7107b1cd

### Video showing result with `shrink-0` applied

https://github.com/themesberg/flowbite-svelte/assets/8170676/84269753-b0c0-4ca1-b279-41ec601222ce


## Status

- [x] Not Completed
- [ ] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).