### PR TITLE
fix(Input): Use a reactive spread instead of custom action to set Input `type` attribute

### DIFF
--- a/src/lib/forms/Input.svelte
+++ b/src/lib/forms/Input.svelte
@@ -14,7 +14,7 @@
   export let type: InputType = 'text';
   export let value: any = undefined;
   export let size: FormSizeType | undefined = undefined;
-  export let defaultClass: string = 'block w-full disabled:cursor-not-allowed disabled:opacity-50';
+  export let defaultClass: string = 'block w-full border disabled:cursor-not-allowed disabled:opacity-50';
   export let color: 'base' | 'green' | 'red' = 'base';
   export let floatClass: string = 'flex absolute inset-y-0 items-center text-gray-500 dark:text-gray-400';
 

--- a/src/lib/forms/Input.svelte
+++ b/src/lib/forms/Input.svelte
@@ -45,16 +45,6 @@
 
   let group: { size: SizeType } = getContext('group');
 
-  // you need to this to avoid 2-way binding
-  const setType = (node: HTMLInputElement, _type: string) => {
-    node.type = _type;
-    return {
-      update(_type: string) {
-        node.type = _type;
-      }
-    };
-  };
-
   const textSizes = { sm: 'sm:text-xs', md: 'text-sm', lg: 'sm:text-base' };
   const leftPadding = { sm: 'pl-9', md: 'pl-10', lg: 'pl-11' };
   const rightPadding = { sm: 'pr-9', md: 'pr-10', lg: 'pr-11' };
@@ -102,7 +92,7 @@
       on:mouseleave
       on:paste
       on:input
-      use:setType={type}
+      {...{ type }}
       class={inputClass} />
   </slot>
   {#if $$slots.right}

--- a/src/lib/forms/Input.svelte
+++ b/src/lib/forms/Input.svelte
@@ -14,7 +14,7 @@
   export let type: InputType = 'text';
   export let value: any = undefined;
   export let size: FormSizeType | undefined = undefined;
-  export let defaultClass: string = 'block w-full border disabled:cursor-not-allowed disabled:opacity-50';
+  export let defaultClass: string = 'block w-full disabled:cursor-not-allowed disabled:opacity-50';
   export let color: 'base' | 'green' | 'red' = 'base';
   export let floatClass: string = 'flex absolute inset-y-0 items-center text-gray-500 dark:text-gray-400';
 


### PR DESCRIPTION

## 📑 Description
Adjust the way the type attribute is set to use a reactively spread object rather than a custom action to circumvent the svelte warning. The motivation for this change is that currently the border is dependent on a `type` attribute being set on the input, which gets its styling from the global Flowbite CSS file. 

This causes a brief flicker in the input's border given the attribute is being set with javascript after it first mounts, and just doesn't render a border at all if JS is disabled.

With the reactive spread, the input does have the type attribute already set on mount so the border will be present even without JS.

<!-- Add a brief description of the PR -->

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Also not sure if the border class should just be added in the defaultClass as well, but this is a less breaking change.
