### PR TITLE
fix: workaround for scroll to anchor

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
   import { DarkMode, Navbar, NavBrand, NavHamburger, NavLi, NavUl } from '$lib';
   import Tooltip from '$lib/tooltips/Tooltip.svelte';
-  import { setContext } from 'svelte';
+  import { onMount, setContext } from 'svelte';
   import { writable, type Writable } from 'svelte/store';
   import '../app.css';
   import DocBadge from './utils/DocBadge.svelte';
@@ -12,6 +12,7 @@
   import ToolbarLink from './utils/ToolbarLink.svelte';
   import NavSidebarHamburger from '$lib/navbar/NavSidebarHamburger.svelte';
   import AlgoliaSearch from './utils/AlgoliaSearch.svelte';
+    import { browser } from '$app/environment';
 
   let isHomePage: boolean;
   $: isHomePage = $page.route.id === '/';
@@ -30,6 +31,19 @@
   const toggleDrawer = () => {
     drawerHiddenStore.update((state) => !state);
   };
+
+  onMount(()=> {
+    // Workaround until https://github.com/sveltejs/kit/issues/2664 is fixed
+    if (typeof window !== "undefined" && window.location.hash) {
+      const deepLinkedElement = document.getElementById(
+        window.location.hash.substring(1)
+      );
+
+      if (deepLinkedElement) {
+        window.setTimeout(() => deepLinkedElement.scrollIntoView(), 100);
+      }
+    }
+  })
 </script>
 
 <header


### PR DESCRIPTION
## 📑 Description

Workaround for scrolling to the anchor when copy/pasting url in the navigation bar of the browser.
Source: https://github.com/sveltejs/kit/issues/2664
## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
