### PR TITLE
fix(FloatingLabelInput): Use reactive spread for type attribute

### DIFF
--- a/src/lib/forms/FloatingLabelInput.svelte
+++ b/src/lib/forms/FloatingLabelInput.svelte
@@ -76,16 +76,6 @@
     green: 'text-green-600 dark:text-green-500',
     red: 'text-red-600 dark:text-red-500'
   };
-
-  // you need to this to avoid 2-way binding
-  function setType(node: HTMLInputElement, _type: string) {
-    node.type = _type;
-    return {
-      update(_type: string) {
-        node.type = _type;
-      }
-    };
-  }
 </script>
 
 <div class={twMerge(divClasses[style], $$props.classDiv)}>
@@ -105,7 +95,7 @@
     on:mouseleave
     on:mouseover
     on:paste
-    use:setType={type}
+    {...{type}}
     placeholder=" "
     class={twMerge(
       inputClasses[style],


### PR DESCRIPTION
## 📑 Description
Use a reactive spread for floating label input type attribute, consistent with change from #921 

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
