### PR TITLE
fix: Added z-50 to dropdown container so it always stays on top

### DIFF
--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -29,7 +29,7 @@
   }
 </script>
 
-<Popper activeContent {...$$restProps} class={'divide-y'} on:show bind:open>
+<Popper activeContent {...$$restProps} class={'divide-y z-50'} on:show bind:open>
   {#if $$slots.header}
     <div class={headerCls}>
       <slot name="header" />
@@ -83,7 +83,7 @@
   <script>
     import { Button, Dropdown, DropdownItem, Chevron } from 'flowbite-svelte'
   </script>
-  
+
   <Button><Chevron>Dropdown button</Chevron></Button>
   <Dropdown >
     <DropdownItem>Dashboard</DropdownItem>

--- a/src/lib/dropdowns/Dropdown.svelte
+++ b/src/lib/dropdowns/Dropdown.svelte
@@ -4,16 +4,19 @@
   import type { ComponentProps } from 'svelte';
 
   export let open: boolean = false;
+  export let containerClass: string = 'divide-y z-50';
   export let headerClass: string = 'py-1 overflow-hidden rounded-t-lg';
   export let footerClass: string = 'py-1 overflow-hidden rounded-b-lg';
 
   // propagate props type from underlying Frame
   interface $$Props extends ComponentProps<Popper> {
     open?: boolean;
+    containerClass?: string;
     headerClass?: string;
     footerClass?: string;
   }
 
+  let containerCls: string = twMerge(containerClass, $$props.classContainer);
   let headerCls: string = twMerge(headerClass, $$props.classHeader);
   let ulCls: string = twMerge('py-1', $$props.class);
   let footerCls: string = twMerge(footerClass, $$props.classFooter);
@@ -29,7 +32,7 @@
   }
 </script>
 
-<Popper activeContent {...$$restProps} class={'divide-y z-50'} on:show bind:open>
+<Popper activeContent {...$$restProps} class={containerCls} on:show bind:open>
   {#if $$slots.header}
     <div class={headerCls}>
       <slot name="header" />
@@ -75,6 +78,7 @@
   - Events
   ## Props
   @prop open: boolean = false;
+  @prop containerClass: string = 'divide-y z-50';
   @prop headerClass: string = 'py-1 overflow-hidden rounded-t-lg';
   @prop ulClass: string = 'py-1 w-44';
   @prop footerClass: string = 'py-1 overflow-hidden rounded-b-lg';

--- a/src/routes/docs/components/dropdown.md
+++ b/src/routes/docs/components/dropdown.md
@@ -622,6 +622,7 @@ The component has the following props, type, and default values. See [types page
 
 ### Dropdown
 
+- Use the `classContainer` prop to overwrite `containerClass`.
 - Use the `classHeader` prop to overwrite `headerClass`.
 - Use the `classUl` prop to overwrite `ulClass`.
 - Use the `classFooter` prop to overwrite `footerClass`.

--- a/src/routes/props/Dropdown.json
+++ b/src/routes/props/Dropdown.json
@@ -1,6 +1,7 @@
 {
   "props": [
     ["open", "boolean", "false"],
+    ["containerClass", "string", "'divide-y z-50'"],
     ["headerClass", "string", "'py-1 overflow-hidden rounded-t-lg'"],
     ["footerClass", "string", "'py-1 overflow-hidden rounded-b-lg'"]
   ]


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #939 
Closes #897

## 📑 Description

Added `z-50` to the dropdown container so it always stays on-top of all elements (e.g. no longer hidden behind a `ListGroupitem`.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
