### PR TITLE
feat: Improve Carousel, additional styling options, mixed image size support

### DIFF
--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -15,39 +15,39 @@
   export let duration: number = 2000;
 
   // Carousel
-  export let divClass = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
-  let divCls = twMerge(divClass, $$props.classDiv);
-  export let indicatorDivClass = 'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2';
-  let indicatorDivCls = twMerge(indicatorDivClass, $$props.classIndicatorDiv);
+  export let divClass: string = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
+  let divCls: string = twMerge(divClass, $$props.classDiv);
+  export let indicatorDivClass: string = 'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2';
+  let indicatorDivCls: string = twMerge(indicatorDivClass, $$props.classIndicatorDiv);
 
   // Caption
-  export let captionClass = 'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center';
-  let captionCls = twMerge(captionClass, $$props.classCaption);
+  export let captionClass: string = 'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center';
+  let captionCls: string = twMerge(captionClass, $$props.classCaption);
 
   // Indicator
-  export let indicatorClass = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
-  let indicatorCls = twMerge(indicatorClass, $$props.classIndicator);
+  export let indicatorClass: string = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
+  let indicatorCls: string = twMerge(indicatorClass, $$props.classIndicator);
 
   // Slide
-  export let slideClass = 'flex items-center justify-center h-full w-full';
-  let slideCls = twMerge(slideClass, $$props.classSlide);
+  export let slideClass: string = 'flex items-center justify-center h-full w-full';
+  let slideCls: string = twMerge(slideClass, $$props.classSlide);
 
   // Img
   export let imgFit: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down' = 'cover';
-  export let imgClass = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;
-  let imgCls = twMerge(imgClass, $$props.classImg);
+  export let imgClass: string = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;
+  let imgCls: string = twMerge(imgClass, $$props.classImg);
 
   // Thumbnail
-  export let thumbClass = 'opacity-40';
-  let thumbCls = twMerge(thumbClass, $$props.classThumb);
+  export let thumbClass: string = 'opacity-40';
+  let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
 
   // Thumbnail Container
-  export let thumbDivClass = 'flex flex-row justify-center bg-gray-100 w-full';
-  let thumbDivCls = twMerge(thumbDivClass, $$props.classThumbDiv);
+  export let thumbDivClass: string = 'flex flex-row justify-center bg-gray-100 w-full';
+  let thumbDivCls: string = twMerge(thumbDivClass, $$props.classThumbDiv);
 
   // Thumbnail Img Btn Div
-  export let thumbBtnClass = '';
-  let thumbBtnCls = twMerge(thumbBtnClass, $$props.classBtnThumb);
+  export let thumbBtnClass: string = '';
+  let thumbBtnCls: string = twMerge(thumbBtnClass, $$props.classBtnThumb);
 
   let imageShowingIndex: number = 0;
   $: image = images[imageShowingIndex];

--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -34,7 +34,7 @@
 
   // Img
   export let imgFit: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down' = 'cover';
-  export let imgClass = `object-${imgFit} h-full w-full`;
+  export let imgClass = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;
   let imgCls = twMerge(imgClass, $$props.classImg);
 
   // Thumbnail

--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -15,28 +15,36 @@
   export let duration: number = 2000;
 
   // Carousel
-  export let divClass: string = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
-  let divCls: string = twMerge(divClass, $$props.classDiv);
-  export let indicatorDivClass: string = 'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2';
-  let indicatorDivCls: string = twMerge(indicatorDivClass, $$props.classIndicatorDiv);
+  export let divClass = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
+  let divCls = twMerge(divClass, $$props.classDiv);
+  export let indicatorDivClass = 'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2';
+  let indicatorDivCls = twMerge(indicatorDivClass, $$props.classIndicatorDiv);
+
   // Caption
-  export let captionClass: string = 'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center';
-  let captionCls: string = twMerge(captionClass, $$props.classCaption);
+  export let captionClass = 'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center';
+  let captionCls = twMerge(captionClass, $$props.classCaption);
+
   // Indicator
-  export let indicatorClass: string = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
-  let indicatorCls: string = twMerge(indicatorClass, $$props.classIndicator);
+  export let indicatorClass = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
+  let indicatorCls = twMerge(indicatorClass, $$props.classIndicator);
+
   // Slide
-  export let slideClass: string = 'flex items-center justify-center h-full w-full';
-  let slideCls: string = twMerge(slideClass, $$props.classSlide);
+  export let slideClass = 'flex items-center justify-center h-full w-full';
+  let slideCls = twMerge(slideClass, $$props.classSlide);
+
   // Img
-  export let imgClass: string = 'object-contain h-full';
-  let imgCls: string = twMerge(imgClass, $$props.classImg);
+  export let imgFit: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down' = 'cover';
+  export let imgClass = `object-${imgFit} h-full w-full`;
+  let imgCls = twMerge(imgClass, $$props.classImg);
+
   // Thumbnail
-  export let thumbClass: string = 'opacity-40';
-  let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
+  export let thumbClass = 'opacity-40';
+  let thumbCls = twMerge(thumbClass, $$props.classThumb);
+
   // Thumbnail Container
   export let thumbDivClass = 'flex flex-row justify-center bg-gray-100 w-full';
   let thumbDivCls = twMerge(thumbDivClass, $$props.classThumbDiv);
+
   // Thumbnail Img Btn Div
   export let thumbBtnClass = '';
   let thumbBtnCls = twMerge(thumbBtnClass, $$props.classBtnThumb);

--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -13,7 +13,6 @@
   export let slideControls: boolean = true;
   export let loop: boolean = false;
   export let duration: number = 2000;
-  export let thumbClass: string = 'opacity-40';
 
   // Carousel
   export let divClass: string = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
@@ -27,7 +26,20 @@
   export let indicatorClass: string = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
   let indicatorCls: string = twMerge(indicatorClass, $$props.classIndicator);
   // Slide
-  export let slideClass: string = '';
+  export let slideClass: string = 'flex items-center justify-center h-full w-full';
+  let slideCls: string = twMerge(slideClass, $$props.classSlide);
+  // Img
+  export let imgClass: string = 'object-contain h-full';
+  let imgCls: string = twMerge(imgClass, $$props.classImg);
+  // Thumbnail
+  export let thumbClass: string = 'opacity-40';
+  let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
+  // Thumbnail Container
+  export let thumbDivClass = 'flex flex-row justify-center bg-gray-100 w-full';
+  let thumbDivCls = twMerge(thumbDivClass, $$props.classThumbDiv);
+  // Thumbnail Img Btn Div
+  export let thumbBtnClass = '';
+  let thumbBtnCls = twMerge(thumbBtnClass, $$props.classBtnThumb);
 
   let imageShowingIndex: number = 0;
   $: image = images[imageShowingIndex];
@@ -59,7 +71,12 @@
 
 <div {id} class="relative">
   <div class={divCls}>
-    <Slide image={image.imgurl} altTag={image.name} attr={image.attribution} {slideClass} />
+    <Slide
+      image={image.imgurl}
+      altTag={image.name}
+      attr={image.attribution}
+      slideClass={slideCls}
+      imgClass={imgCls} />
   </div>
   {#if showIndicators}
     <!-- Slider indicators -->
@@ -131,10 +148,11 @@
 {/if}
 
 {#if showThumbs}
-  <div class="flex flex-row justify-center bg-gray-100">
+  <div class={thumbDivCls}>
     {#each images as { id, imgurl, name, attribution }}
       <Thumbnail
-        {thumbClass}
+        thumbClass={thumbCls}
+        thumbBtnClass={thumbBtnCls}
         thumbImg={imgurl}
         altTag={name}
         titleLink={attribution}

--- a/src/lib/carousels/CarouselTransition.svelte
+++ b/src/lib/carousels/CarouselTransition.svelte
@@ -7,6 +7,7 @@
   import Caption from './Caption.svelte';
   import Indicator from './Indicator.svelte';
 
+  export let id: string = 'default-transition-carousel';
   export let showIndicators: boolean = true;
   export let showCaptions: boolean = true;
   export let showThumbs: boolean = true;
@@ -91,7 +92,7 @@
   }
 </script>
 
-<div id="default-carousel" class="relative">
+<div {id} class="relative">
   <div class={divCls}>
     {#each images as { id, imgurl, name, attribution }}
       {#if imageShowingIndex === id}

--- a/src/lib/carousels/CarouselTransition.svelte
+++ b/src/lib/carousels/CarouselTransition.svelte
@@ -42,11 +42,11 @@
   export let thumbClass: string = 'opacity-40';
   let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
   // Thumbnail Container
-  export let thumbDivClass = 'flex flex-row justify-center bg-gray-100 w-full';
-  let thumbDivCls = twMerge(thumbDivClass, $$props.classThumbDiv);
+  export let thumbDivClass: string = 'flex flex-row justify-center bg-gray-100 w-full';
+  let thumbDivCls: string = twMerge(thumbDivClass, $$props.classThumbDiv);
   // Thumbnail Img Btn Div
-  export let thumbBtnClass = '';
-  let thumbBtnCls = twMerge(thumbBtnClass, $$props.classBtnThumb);
+  export let thumbBtnClass: string = '';
+  let thumbBtnCls: string = twMerge(thumbBtnClass, $$props.classBtnThumb);
 
   // have a custom transition function that returns the desired transition
   const multiple = (node: HTMLElement, params: any) => {

--- a/src/lib/carousels/CarouselTransition.svelte
+++ b/src/lib/carousels/CarouselTransition.svelte
@@ -16,7 +16,6 @@
   export let transitionParams: TransitionParamTypes = {};
   export let loop: boolean = false;
   export let duration: number = 2000;
-  export let thumbClass: string = 'opacity-40';
 
   // Carousel
   export let divClass: string = 'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96';
@@ -29,6 +28,25 @@
   // Indicator
   export let indicatorClass: string = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
   let indicatorCls: string = twMerge(indicatorClass, $$props.classIndicator);
+  // Slide
+  export let slideClass: string = '';
+  let slideCls: string = twMerge(slideClass, $$props.classSlide);
+  // Transition Div
+  export let transitionDivClass: string = 'h-full w-full';
+  let transitionDivCls: string = twMerge(transitionDivClass, $$props.classTransitionDiv);
+  // Img
+  export let imgClass: string = 'object-contain';
+  let imgCls: string = twMerge(imgClass, $$props.classImg);
+  // Thumbnail
+  export let thumbClass: string = 'opacity-40';
+  let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
+  // Thumbnail Container
+  export let thumbDivClass = 'flex flex-row justify-center bg-gray-100 w-full';
+  let thumbDivCls = twMerge(thumbDivClass, $$props.classThumbDiv);
+  // Thumbnail Img Btn Div
+  export let thumbBtnClass = '';
+  let thumbBtnCls = twMerge(thumbBtnClass, $$props.classBtnThumb);
+
   // have a custom transition function that returns the desired transition
   const multiple = (node: HTMLElement, params: any) => {
     switch (transitionType) {
@@ -77,8 +95,8 @@
   <div class={divCls}>
     {#each images as { id, imgurl, name, attribution }}
       {#if imageShowingIndex === id}
-        <div transition:multiple={transitionParams}>
-          <Slide image={imgurl} altTag={name} attr={attribution} />
+        <div transition:multiple={transitionParams} class={transitionDivCls}>
+          <Slide image={imgurl} altTag={name} attr={attribution} slideClass={slideCls} imgClass={imgCls} />
         </div>
       {/if}
     {/each}
@@ -154,10 +172,11 @@
 {/if}
 
 {#if showThumbs}
-  <div class="flex flex-row justify-center bg-gray-100">
+  <div class={thumbDivCls}>
     {#each images as { id, imgurl, name, attribution }}
       <Thumbnail
-        {thumbClass}
+        thumbClass={thumbCls}
+        thumbBtnClass={thumbBtnCls}
         thumbImg={imgurl}
         altTag={name}
         titleLink={attribution}

--- a/src/lib/carousels/CarouselTransition.svelte
+++ b/src/lib/carousels/CarouselTransition.svelte
@@ -23,27 +23,36 @@
   let divCls: string = twMerge(divClass, $$props.classDiv);
   export let indicatorDivClass: string = 'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2';
   let indicatorDivCls: string = twMerge(indicatorDivClass, $$props.classIndicatorDiv);
+
   // Caption
   export let captionClass: string = 'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center';
   let captionCls: string = twMerge(captionClass, $$props.classCaption);
+
   // Indicator
   export let indicatorClass: string = 'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60';
   let indicatorCls: string = twMerge(indicatorClass, $$props.classIndicator);
+
   // Slide
   export let slideClass: string = '';
   let slideCls: string = twMerge(slideClass, $$props.classSlide);
+
   // Transition Div
   export let transitionDivClass: string = 'h-full w-full';
   let transitionDivCls: string = twMerge(transitionDivClass, $$props.classTransitionDiv);
+
   // Img
-  export let imgClass: string = 'object-contain';
+  export let imgFit: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down' = 'cover';
+  export let imgClass: string = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;
   let imgCls: string = twMerge(imgClass, $$props.classImg);
+
   // Thumbnail
   export let thumbClass: string = 'opacity-40';
   let thumbCls: string = twMerge(thumbClass, $$props.classThumb);
+
   // Thumbnail Container
   export let thumbDivClass: string = 'flex flex-row justify-center bg-gray-100 w-full';
   let thumbDivCls: string = twMerge(thumbDivClass, $$props.classThumbDiv);
+
   // Thumbnail Img Btn Div
   export let thumbBtnClass: string = '';
   let thumbBtnCls: string = twMerge(thumbBtnClass, $$props.classBtnThumb);

--- a/src/lib/carousels/Slide.svelte
+++ b/src/lib/carousels/Slide.svelte
@@ -3,10 +3,13 @@
   export let altTag: string = '';
   export let attr: string = '';
   export let slideClass: string = '';
+  export let imgClass: string = '';
 </script>
 
 <div class={slideClass}>
-  <img src={image} alt={altTag} title={attr} />
+  {#key image}
+    <img src={image} alt={altTag} title={attr} class={imgClass} />
+  {/key}
 </div>
 
 <!--

--- a/src/lib/carousels/Thumbnail.svelte
+++ b/src/lib/carousels/Thumbnail.svelte
@@ -6,10 +6,11 @@
   export let thumbWidth: number = 100;
   export let selected: boolean = false;
   export let thumbClass: string = '';
+  export let thumbBtnClass: string = '';
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<button on:click aria-label="Click to view image">
+<button on:click aria-label="Click to view image" class={thumbBtnClass}>
   <img
     class={thumbClass}
     class:active={selected}

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -265,7 +265,7 @@ The carousel component can be used to cycle through a set of elements using cust
   import { images } from './imageData/+server.js';
 </script>
 
-<div class="max-w-4xl dark bg-gray-100 p-2">
+<div class="max-w-4xl dark p-2 bg-gray-100 dark:bg-gray-800">
   <Carousel
     {images}
     showCaptions={false}

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -251,8 +251,32 @@ The carousel component can be used to cycle through a set of elements using cust
   import { images } from './imageData/+server.js';
   import { bounceInOut } from 'svelte/easing';
 </script>
+
 <div class="max-w-4xl">
   <CarouselTransition {images} transitionType="slide" transitionParams="{{duration: 1500, easing: bounceInOut}}" showCaptions={false} showThumbs={false}/>
+</div>
+```
+
+## Custom Styling
+
+```svelte example
+<script>
+  import { Carousel } from 'flowbite-svelte'
+  import { images } from './imageData/+server.js';
+</script>
+
+<div class="max-w-4xl dark bg-gray-100 p-2">
+  <Carousel
+    {images}
+    showCaptions={false}
+    classSlide="flex items-center justify-center h-full w-full !rounded-none !bg-transparent"
+    classDiv="w-[100%] !h-[300px] sm:!h-[400px] !rounded-none !bg-transparent"
+    imgFit="contain"
+    classImg="!bg-none !rounded-md animate-[fadeIn_.5s_ease-in-out_1] h-full"
+    classThumb="p-0 rounded-md shadow-xl hover:outline hover:outline-primary-500"
+    classThumbDiv="bg-transparent"
+    thumbBtnClass="m-2"
+  />
 </div>
 ```
 

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -266,6 +266,11 @@ The component has the following props, type, and default values. See [types page
 - Use the `classIndicatorDiv` prop to overwrite `indicatorDivCls`.
 - Use the `classCaption` prop to overwrite `captionClass`.
 - Use the `classIndicator` prop to overwrite `indicatorClass`.
+- Use the `classSlide` prop to overwrite `slideClass`.
+- Use the `classThumb` prop to overwrite `thumbClass`.
+- Use the `classThumbDiv` prop to overwrite `thumbClassDiv`.
+- Use the `classBtnThumb` prop to overwrite `thumbBtnClass`.
+- Use the `classBtnThumb` prop to overwrite `thumbBtnClass`.
 
 <TableProp>
   <TableDefaultRow {items} rowState='hover' />

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -270,7 +270,7 @@ The carousel component can be used to cycle through a set of elements using cust
     {images}
     showCaptions={false}
     classSlide="flex items-center justify-center h-full w-full !rounded-none !bg-transparent"
-    classDiv="w-[100%] !h-[300px] sm:!h-[400px] !rounded-none !bg-transparent"
+    classDiv="w-full !h-[300px] sm:!h-[400px] !rounded-none !bg-transparent"
     imgFit="contain"
     classImg="!bg-none !rounded-md animate-[fadeIn_.5s_ease-in-out_1] h-full"
     classThumb="p-0 rounded-md shadow-xl hover:outline hover:outline-primary-500"

--- a/src/routes/props/Carousel.json
+++ b/src/routes/props/Carousel.json
@@ -14,7 +14,7 @@
     ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"],
     ["slideClass", "string", "'flex items-center justify-center h-full w-full'"],
     ["imgFit", "'cover' | 'contain' | 'fill' | 'none' | 'scale-down'", "'cover'"],
-    ["imgClass", "string", "`object-${imgFit} h-full w-full`"],
+    ["imgClass = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;", "string", ""],
     ["thumbClass", "string", "'opacity-40'"],
     ["thumbDivClass", "string", "'flex flex-row justify-center bg-gray-100 w-full'"],
     ["thumbBtnClass", "string", "''"]

--- a/src/routes/props/Carousel.json
+++ b/src/routes/props/Carousel.json
@@ -8,11 +8,15 @@
     ["slideControls", "boolean", "true"],
     ["loop", "boolean", "false"],
     ["duration", "number", "2000"],
-    ["thumbClass", "string", "'opacity-40'"],
     ["divClass", "string", "'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96'"],
     ["indicatorDivClass", "string", "'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2'"],
     ["captionClass", "string", "'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center'"],
     ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"],
-    ["slideClass", "string", "''"]
+    ["slideClass", "string", "'flex items-center justify-center h-full w-full'"],
+    ["imgFit", "'cover' | 'contain' | 'fill' | 'none' | 'scale-down'", "'cover'"],
+    ["imgClass", "string", "`object-${imgFit} h-full w-full`"],
+    ["thumbClass", "string", "'opacity-40'"],
+    ["thumbDivClass", "string", "'flex flex-row justify-center bg-gray-100 w-full'"],
+    ["thumbBtnClass", "string", "''"]
   ]
 }

--- a/src/routes/props/Carousel.json
+++ b/src/routes/props/Carousel.json
@@ -14,7 +14,7 @@
     ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"],
     ["slideClass", "string", "'flex items-center justify-center h-full w-full'"],
     ["imgFit", "'cover' | 'contain' | 'fill' | 'none' | 'scale-down'", "'cover'"],
-    ["imgClass = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;", "string", ""],
+    ["imgClass", "string = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;", ""],
     ["thumbClass", "string", "'opacity-40'"],
     ["thumbDivClass", "string", "'flex flex-row justify-center bg-gray-100 w-full'"],
     ["thumbBtnClass", "string", "''"]

--- a/src/routes/props/CarouselTransition.json
+++ b/src/routes/props/CarouselTransition.json
@@ -16,7 +16,8 @@
     ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"],
     ["slideClass", "string", "''"],
     ["transitionDivClass", "string", "'h-full w-full'"],
-    ["imgClass", "string", "'object-contain'"],
+    ["imgFit", "'cover' | 'contain' | 'fill' | 'none' | 'scale-down'", "'cover'"],
+    ["imgClass", "string = `object-${imgFit} ${imgFit === 'cover' && 'w-full'} h-full`;", ""],
     ["thumbClass", "string", "'opacity-40'"],
     ["thumbDivClass", "string", "'flex flex-row justify-center bg-gray-100 w-full'"],
     ["thumbBtnClass", "string", "''"]

--- a/src/routes/props/CarouselTransition.json
+++ b/src/routes/props/CarouselTransition.json
@@ -9,10 +9,15 @@
     ["transitionParams", "TransitionParamTypes", "{}"],
     ["loop", "boolean", "false"],
     ["duration", "number", "2000"],
-    ["thumbClass", "string", "'opacity-40'"],
     ["divClass", "string", "'overflow-hidden relative h-56 rounded-lg sm:h-64 xl:h-80 2xl:h-96'"],
     ["indicatorDivClass", "string", "'flex absolute bottom-5 left-1/2 z-30 space-x-3 -translate-x-1/2'"],
     ["captionClass", "string", "'h-10 bg-gray-300 dark:bg-gray-700 dark:text-white p-2 my-2 text-center'"],
-    ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"]
+    ["indicatorClass", "string", "'w-3 h-3 rounded-full bg-gray-100 hover:bg-gray-300 opacity-60'"],
+    ["slideClass", "string", "''"],
+    ["transitionDivClass", "string", "'h-full w-full'"],
+    ["imgClass", "string", "'object-contain'"],
+    ["thumbClass", "string", "'opacity-40'"],
+    ["thumbDivClass", "string", "'flex flex-row justify-center bg-gray-100 w-full'"],
+    ["thumbBtnClass", "string", "''"]
   ]
 }

--- a/src/routes/props/CarouselTransition.json
+++ b/src/routes/props/CarouselTransition.json
@@ -1,5 +1,6 @@
 {
   "props": [
+    ["id", "string", "'default-transition-carousel'"],
     ["showIndicators", "boolean", "true"],
     ["showCaptions", "boolean", "true"],
     ["showThumbs", "boolean", "true"],

--- a/src/routes/props/Slide.json
+++ b/src/routes/props/Slide.json
@@ -3,6 +3,7 @@
     ["image", "string", "''"],
     ["altTag", "string", "''"],
     ["attr", "string", "''"],
-    ["slideClass", "string", "''"]
+    ["slideClass", "string", "''"],
+    ["imgClass", "string", "''"]
   ]
 }

--- a/src/routes/props/Thumbnail.json
+++ b/src/routes/props/Thumbnail.json
@@ -6,6 +6,7 @@
     ["id", "number", ""],
     ["thumbWidth", "number", "100"],
     ["selected", "boolean", "false"],
-    ["thumbClass", "string", "''"]
+    ["thumbClass", "string", "''"],
+    ["thumbBtnClass", "string", "''"]
   ]
 }


### PR DESCRIPTION
## 📑 Description
There are many parts of the Carousel component that aren't exposed, and thus it is not possible to style every aspect of the Carousel's DOM; this makes it difficult to alter styling of certain elements such as thumbnails or the `img` element. 

Also, the current Carousel doesn't work well when images are different sizes. This PR adds features exposing previously hidden DOM element classes for more control, and improves support for mixed image sizes. 

Here's a summary of additions:
- Adds Image Class functionality (`img` element styling & enables animations at the `img` level by wrapping in `{#key}`)
- Adds `imgFit` prop which allows for setting `object-fit`, allowing for displaying entire image in Slide `contain` or filling entire slide with `cover` (default)
- Adds `thumbClass` (Thumbnail Wrapper, allows for controlling opacity etc)
- Adds `thumbDivClass` (Thumbnail Div, allows for changing color and grid layout)
- Adds `thumbBtnClass` (Tumbnail Button element styling, allows for mouseover effects)
- Adds `transitionDivClass` (Transition Wrapper Element styling support)
- `slideClass` has added Tailwind Merge support

Here's a live example (loads random gallery images on every page load to test different image sizes): [https://flowbite-gallery-example.netlify.app/](https://flowbite-gallery-example.netlify.app/)


## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information
Here's a live example (loads random gallery images on every page load to test different image sizes): [https://flowbite-gallery-example.netlify.app/](https://flowbite-gallery-example.netlify.app/)