### PR TITLE
fix: border color on popup examples

### DIFF
--- a/src/routes/docs/components/popover.md
+++ b/src/routes/docs/components/popover.md
@@ -355,7 +355,7 @@ If you need the popover to be attached to the other element then the tiggering o
   let placement = "";
 </script>
 
-<div id="ext-ref" class="p-2 rounded-lg border">External reference</div>
+<div id="ext-ref" class="p-2 rounded-lg border border-gray-200 dark:border-gray-600">External reference</div>
 <div class="space-x-4">
 <Button id="ref-1" on:mouseenter={()=> placement="left"}>Left</Button>
 <Button id="ref-2" on:mouseenter={()=> placement="top"}>Top</Button>

--- a/src/routes/docs/components/tooltip.md
+++ b/src/routes/docs/components/tooltip.md
@@ -109,7 +109,7 @@ If you need the tooltip to be attached to the other element then the tiggering o
   let placement = "";
 </script>
 
-<div id="ext-ref" class="p-2 rounded-lg border">External reference</div>
+<div id="ext-ref" class="p-2 rounded-lg border border-gray-200 dark:border-gray-600">External reference</div>
 <div class="space-x-4">
 <Button id="ref-left" on:mouseenter={()=> placement="left"}>Left</Button>
 <Button id="ref-top" on:mouseenter={()=> placement="top"}>Top</Button>


### PR DESCRIPTION
## 📑 Description

Border color on `External reference` examples for `Tooltip` and `Popover`.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
