### PR TITLE
Match ButtonColorType to Button component ButtonColor

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,7 +4,7 @@ export type BlockQuoteType = 'xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl' 
 
 export type ButtonType = 'button' | 'submit' | 'reset';
 
-export type ButtonColorType = 'alternative' | 'blue' | 'cyan' | 'dark' | 'light' | 'lime' | 'green' | 'pink' | 'primary' | 'red' | 'teal' | 'yellow' | 'purple' | 'purpleToBlue' | 'cyanToBlue' | 'greenToBlue' | 'purpleToPink' | 'pinkToOrange' | 'tealToLime' | 'redToYellow';
+export type ButtonColorType = 'alternative' | 'blue' | 'dark' | 'green' | 'light' | 'primary' | 'purple' | 'red' | 'yellow' | 'none';
 
 export type Colors = 'blue' | 'gray' | 'red' | 'yellow' | 'purple' | 'green' | 'indigo' | 'pink' | 'white' | 'custom' | 'primary' | 'secondary';
 


### PR DESCRIPTION
## 📑 Description

Makes the exported `ButtonColorType` match the type for the `Button` component's `ButtonColor` type.

When creating a custom `Button` type to set a default color as per the recommendation [in the docs](https://flowbite-svelte.com/docs/pages/customization#Global_customization), using the `ButtonColorType` exported by `flowbite-svelte/dist/types` generates a type error. `ButtonColorType` does not match the colors defined by the `ButtonColor` type on the `Button` component. This PR syncs them up.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
