### PR TITLE
feat: add dialogClass prop to Modal

### DIFF
--- a/src/lib/modals/Modal.svelte
+++ b/src/lib/modals/Modal.svelte
@@ -16,6 +16,7 @@
     autoclose?: boolean;
     permanent?: boolean;
     backdropClass?: string;
+    dialogClass?: string;
     defaultClass?: string;
     outsideclose?: boolean;
   }
@@ -27,6 +28,7 @@
   export let autoclose: boolean = false;
   export let permanent: boolean = false;
   export let backdropClass: string = 'bg-gray-900 bg-opacity-50 dark:bg-opacity-80';
+  export let dialogClass: string = '';
   export let defaultClass: string = 'relative flex flex-col mx-auto';
   export let outsideclose: boolean = false;
 
@@ -99,6 +101,8 @@
   let frameClass: string;
   $: frameClass = twMerge(defaultClass, 'w-full', $$props.class);
 
+  let dialogCls: string = twMerge(dialogClass, $$props.classDialog);
+
   const isScrollable = (e: HTMLElement): boolean[] => [e.scrollWidth > e.clientWidth && ['scroll', 'auto'].indexOf(getComputedStyle(e).overflowX) >= 0, e.scrollHeight > e.clientHeight && ['scroll', 'auto'].indexOf(getComputedStyle(e).overflowY) >= 0];
 
   let backdropCls: string = twMerge(backdropClass, $$props.classBackdrop);
@@ -113,7 +117,7 @@
   <div class={twMerge('fixed inset-0 z-40', backdropCls)} />
   <!-- dialog -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} class={twMerge('fixed top-0 left-0 right-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 flex', ...getPlacementClasses())} tabindex="-1" aria-modal="true" role="dialog">
+  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} class={twMerge('fixed top-0 left-0 right-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 flex', ...getPlacementClasses(), dialogCls)} tabindex="-1" aria-modal="true" role="dialog">
     <div class="flex relative {sizes[size]} w-full max-h-full">
       <!-- Modal content -->
       <Frame rounded shadow {...$$restProps} class={frameClass}>
@@ -167,6 +171,7 @@
   @prop autoclose: boolean = false;
   @prop permanent: boolean = false;
   @prop backdropClass: string = 'bg-gray-900 bg-opacity-50 dark:bg-opacity-80';
+  @prop dialogClass: string = '';
   @prop defaultClass: string = 'relative flex flex-col mx-auto';
   @prop outsideclose: boolean = false; 
   ## Example

--- a/src/routes/docs/components/modal.md
+++ b/src/routes/docs/components/modal.md
@@ -402,6 +402,7 @@ The component has the following props, type, and default values. See [types page
 
 - Use the `class` prop to overwrite `defaultClass`.
 - Use the `classBackdrop` prop to overwrite `backdropClass`.
+- Use the `classDialog` prop to overwrite `dialogClass`.
 - Use the `bodyClass` prop to overwrite body modal default class.
 
 <TableProp>

--- a/src/routes/props/Modal.json
+++ b/src/routes/props/Modal.json
@@ -7,6 +7,7 @@
     ["autoclose", "boolean", "false"],
     ["permanent", "boolean", "false"],
     ["backdropClass", "string", "'bg-gray-900 bg-opacity-50 dark:bg-opacity-80'"],
+    ["dialogClass", "string", "''"],
     ["defaultClass", "string", "'relative flex flex-col mx-auto'"],
     ["outsideclose", "boolean", "false"]
   ]


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #994

## 📑 Description

Add a `dialogClass` prop and corresponding `classDialog` anonymous prop to the `Modal` component.
This new prop allows specifying custom CSS properties for the div containing the actual shown modal content.
In my case, it allows me to specify a custom `z-index` to display it on top of other components.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/ (**This returns a ton of errors, not caused by this change lol**)
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
n.a.
