### PR TITLE
docs: add newline after each <p> element in examples

### DIFF
--- a/src/routes/docs/components/typography.md
+++ b/src/routes/docs/components/typography.md
@@ -22,7 +22,19 @@ We have listed some of the commonly used typography classes that we use througho
 Use the following text-size utility classes from Tailwind to set the font size for any text element.
 
 ```svelte example
-<p class="text-xs dark:text-white">Flowbite</p><p class="text-sm dark:text-white">FlowBite</p><p class="text-base dark:text-white">FlowBite</p><p class="text-lg dark:text-white">FlowBite</p><p class="text-xl dark:text-white">FlowBite</p><p class="text-2xl dark:text-white">FlowBite</p><p class="text-3xl dark:text-white">FlowBite</p><p class="text-4xl dark:text-white">FlowBite</p><p class="text-5xl dark:text-white">FlowBite</p><p class="text-6xl dark:text-white">FlowBite</p><p class="text-7xl dark:text-white">FlowBite</p><p class="text-8xl dark:text-white">FlowBite</p><p class="text-9xl dark:text-white">FlowBite</p>
+<p class="text-xs dark:text-white">Flowbite</p>
+<p class="text-sm dark:text-white">FlowBite</p>
+<p class="text-base dark:text-white">FlowBite</p>
+<p class="text-lg dark:text-white">FlowBite</p>
+<p class="text-xl dark:text-white">FlowBite</p>
+<p class="text-2xl dark:text-white">FlowBite</p>
+<p class="text-3xl dark:text-white">FlowBite</p>
+<p class="text-4xl dark:text-white">FlowBite</p>
+<p class="text-5xl dark:text-white">FlowBite</p>
+<p class="text-6xl dark:text-white">FlowBite</p>
+<p class="text-7xl dark:text-white">FlowBite</p>
+<p class="text-8xl dark:text-white">FlowBite</p>
+<p class="text-9xl dark:text-white">FlowBite</p>
 ```
 
 ## Font Weight
@@ -30,7 +42,15 @@ Use the following text-size utility classes from Tailwind to set the font size f
 Use the following font-weight utility classes to set the font weight for any text element.
 
 ```svelte example
-<p class="font-thin dark:text-white">FlowBite</p><p class="font-extralight dark:text-white">FlowBite</p><p class="font-light dark:text-white">FlowBite</p><p class="font-normal dark:text-white">FlowBite</p><p class="font-medium dark:text-white">FlowBite</p><p class="font-semibold dark:text-white">FlowBite</p><p class="font-bold dark:text-white">FlowBite</p><p class="font-extrabold dark:text-white">FlowBite</p><p class="font-black dark:text-white">FlowBite</p>
+<p class="font-thin dark:text-white">FlowBite</p>
+<p class="font-extralight dark:text-white">FlowBite</p>
+<p class="font-light dark:text-white">FlowBite</p>
+<p class="font-normal dark:text-white">FlowBite</p>
+<p class="font-medium dark:text-white">FlowBite</p>
+<p class="font-semibold dark:text-white">FlowBite</p>
+<p class="font-bold dark:text-white">FlowBite</p>
+<p class="font-extrabold dark:text-white">FlowBite</p>
+<p class="font-black dark:text-white">FlowBite</p>
 ```
 
 ## Line Height
@@ -38,7 +58,12 @@ Use the following font-weight utility classes to set the font weight for any tex
 Use the following leading-type utility classes to set the line height for any text element.
 
 ```svelte example
-<p class="leading-none dark:text-gray-400">Themesberg was created to bring quality ...</p><p class="leading-tight dark:text-gray-400">Themesberg was created to bring quality ...</p><p class="leading-snug dark:text-gray-400">Themesberg was created to bring quality ...</p><p class="leading-normal dark:text-gray-400">Themesberg was created to bring quality ...</p><p class="leading-relaxed dark:text-gray-400">Themesberg was created to bring quality ...</p><p class="leading-loose dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-none dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-tight dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-snug dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-normal dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-relaxed dark:text-gray-400">Themesberg was created to bring quality ...</p>
+<p class="leading-loose dark:text-gray-400">Themesberg was created to bring quality ...</p>
 ```
 
 ## Lists
@@ -98,7 +123,8 @@ Use the list-inside and list-outside classes to set the list item position insid
 You can use the following classes to set the text decoration for any inline text element.
 
 ```svelte example
-<p class="underline dark:text-gray-400">please read our terms and services</p><p class="line-through dark:text-gray-400">please read our terms and services</p>
+<p class="underline dark:text-gray-400">please read our terms and services</p>
+<p class="line-through dark:text-gray-400">please read our terms and services</p>
 ```
 
 ## References


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- Add a brief description of the PR -->

Add a newline after each ``<p>`` element in the examples inside the [docs/components/typography](https://flowbite-svelte.com/docs/components/typography) page.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
