### PR TITLE
Add Frame component to exports

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -219,6 +219,7 @@ export { default as Span } from './typography/Span.svelte';
 
 // utils
 export { default as CloseButton } from './utils/CloseButton.svelte';
+export { default as Frame } from './utils/Frame.svelte';
 
 // video
 export { default as Video } from './video/Video.svelte';


### PR DESCRIPTION
## 📑 Description

I tried to extend a component by copying its contents into my own file, but I ran into issues accessing the `Frame` component:

```
import Frame from 'flowbite-svelte/dist/utils/Frame.svelte';
```

results in:

```
Missing "./dist/utils/Frame.svelte" specifier in "flowbite-svelte" package
```

And:

```
import { Frame } from 'flowbite-svelte';
```

results in:

```
Module "flowbite-svelte" has no exported member 'Frame'.
```

This PR resolves the issue by adding the `Frame` component to the exports in `src/lib/index.ts`

## Status

- [ ] Not Completed
- [X] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [X] All the tests have passed
- [X] My pull request is based on the latest commit (not the npm version).

