### PR TITLE
Bugfix: Carousel Swiper Styling & Direction

### DIFF
--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -148,29 +148,11 @@
 </script>
 
 <!-- The move listeners go here, so things keep working if the touch strays out of the element. -->
-<svelte:document
-  on:mousemove={onDragMove}
-  on:mouseup={onDragStop}
-  on:touchmove={onDragMove}
-  on:touchend={onDragStop} />
+<svelte:document on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} />
 
-<div
-  bind:this={carouselDiv}
-  {id}
-  class="relative"
-  on:mousedown={onDragStart}
-  on:touchstart={onDragStart}
-  role="button"     
-  aria-label="Draggable Carousel"
-  tabindex="0" 
-  >
-  <div
-    style={`transform: translateX(${percentOffset}%)`}
-    class={twJoin(
-      divClass,
-      { 'transition-transform': activeDragGesture === undefined }
-    )}>
-    <Slide image={image.imgurl} altTag={image.name} attr={image.attribution} {slideClass} />
+<div bind:this={carouselDiv} {id} class="relative" on:mousedown={onDragStart} on:touchstart={onDragStart} role="button" aria-label="Draggable Carousel" tabindex="0">
+  <div style={`transform: translateX(${percentOffset}%)`} class={twJoin(divClass, { 'transition-transform': activeDragGesture === undefined })}>
+    <Slide image={image.imgurl} slideClass={slideCls} imgClass={imgCls} altTag={image.name} attr={image.attribution} />
   </div>
   {#if showIndicators}
     <!-- Slider indicators -->

--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -137,10 +137,10 @@
             const distance = position - start;
 
             if (Math.abs(distance) >= SWIPE_MIN_DISTANCE && duration <= SWIPE_MAX_DURATION && duration > 0) {
-              if (distance > 0) nextSlide();
-              else prevSlide();
-            } else if (percentOffset > DRAG_MIN_PERCENT) nextSlide();
-            else if (percentOffset < -DRAG_MIN_PERCENT) prevSlide();
+              if (distance > 0) prevSlide();
+              else nextSlide();
+            } else if (percentOffset > DRAG_MIN_PERCENT) prevSlide();
+            else if (percentOffset < -DRAG_MIN_PERCENT) nextSlide();
           }
           percentOffset = 0;
           activeDragGesture = undefined;
@@ -148,11 +148,32 @@
 </script>
 
 <!-- The move listeners go here, so things keep working if the touch strays out of the element. -->
-<svelte:document on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} />
+<svelte:document
+  on:mousemove={onDragMove}
+  on:mouseup={onDragStop}
+  on:touchmove={onDragMove}
+  on:touchend={onDragStop} />
 
-<div bind:this={carouselDiv} {id} class="relative" on:mousedown={onDragStart} on:touchstart={onDragStart} role="button" aria-label="Draggable Carousel" tabindex="0">
-  <div style={`transform: translateX(${percentOffset}%)`} class={twJoin(divClass, { 'transition-transform': activeDragGesture === undefined })}>
-    <Slide image={image.imgurl} slideClass={slideCls} imgClass={imgCls} altTag={image.name} attr={image.attribution} />
+<div
+  bind:this={carouselDiv}
+  {id}
+  class="relative"
+  on:mousedown={onDragStart}
+  on:touchstart={onDragStart}
+  role="button"
+  aria-label="Draggable Carousel"
+  tabindex="0">
+  <div
+    style={`transform: translateX(${percentOffset}%)`}
+    class={twJoin(
+      divClass,
+      { 'transition-transform': activeDragGesture === undefined })}>
+    <Slide
+      image={image.imgurl}
+      slideClass={slideCls}
+      imgClass={imgCls}
+      altTag={image.name}
+      attr={image.attribution} />
   </div>
   {#if showIndicators}
     <!-- Slider indicators -->

--- a/src/lib/carousels/Carousel.svelte
+++ b/src/lib/carousels/Carousel.svelte
@@ -87,6 +87,7 @@
 
   let carouselDiv: HTMLDivElement;
   let percentOffset: number = 0;
+  let touchEvent: MouseEvent | TouchEvent | null = null;
 
   const getPositionFromEvent = (evt: MouseEvent | TouchEvent) => {
     const mousePos = (evt as MouseEvent)?.clientX;
@@ -99,6 +100,7 @@
   };
 
   const onDragStart = (evt: MouseEvent | TouchEvent) => {
+    touchEvent = evt;
     evt.preventDefault();
     const start = getPositionFromEvent(evt);
     const width = carouselDiv.getBoundingClientRect().width;
@@ -141,9 +143,16 @@
               else nextSlide();
             } else if (percentOffset > DRAG_MIN_PERCENT) prevSlide();
             else if (percentOffset < -DRAG_MIN_PERCENT) nextSlide();
+            else {
+              // The gesture is a tap not drag, so manually issue a click event to trigger tap click gestures lost via preventDefault
+              touchEvent?.target?.dispatchEvent(new Event('click', {
+                bubbles: true,
+              }))
+            }
           }
           percentOffset = 0;
           activeDragGesture = undefined;
+          touchEvent = null;
         };
 </script>
 


### PR DESCRIPTION
## 📑 Description

This PR fixes the custom Carousel styling which was lost when adding swiper component by re-adding custom `imgCls` and `slideCls`.

This PR also inverts the order of the carousel swiper direction to match expected behavior from other swiping libraries such as SwiperJS (swipe from left->right to go back, right->left to go forward).

See: https://github.com/themesberg/flowbite-svelte/pull/965

## Status

- [x] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] All the tests have passed
- [X] My pull request is based on the latest commit (not the npm version).