### PR TITLE
Fix missing dispatch of close events for badges

### DIFF
--- a/src/lib/badges/Badge.svelte
+++ b/src/lib/badges/Badge.svelte
@@ -80,11 +80,11 @@
 
   let open = true;
   const dispatch = createEventDispatcher();
-  $: dispatch(open ? 'open' : 'close');
 
   const close = (e: MouseEvent) => {
     e.stopPropagation();
     open = false;
+    dispatch('close');
   };
 </script>
 


### PR DESCRIPTION
## 📑 Description
The documented example for close events on a dismissable `Badge` is currently not working. The code from the docs is:
```js
<script>
  import { Badge } from 'flowbite-svelte';

  function handleClose(event) {
    alert('Badge dismissed');
  }
</script>

<Badge dismissable large on:close={handleClose}>Default</Badge>
```
Furthermore, the close event still needs to be added to the documentation.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
