### PR TITLE
Bugfix: Carousel swiping event listener error, Feat: Re-Expose Image Class styling for Carousel

### DIFF
--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -88,7 +88,7 @@
     }
   };
 
-  const onDragStart = (evt: MouseEvent | TouchEvent) => {
+  const onDragStart = (evt: MouseEvent | TouchEvent) => { // onDragStart must be invoked with "nonpassive" because of preventDefault
     touchEvent = evt;
     evt.cancelable && evt.preventDefault();
     const start = getPositionFromEvent(evt);
@@ -149,7 +149,7 @@
 
 <!-- The move listeners go here, so things keep working if the touch strays out of the element. -->
 <svelte:document on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} />
-<div bind:this={carouselDiv} class="relative" on:mousedown={onDragStart} on:touchstart|passive={onDragStart} role="button" aria-label={ariaLabel} tabindex="0">
+<div bind:this={carouselDiv} class="relative" on:mousedown|nonpassive={onDragStart} on:touchstart|nonpassive={onDragStart} on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} role="button" aria-label={ariaLabel} tabindex="0">
   <div {...$$restProps} class={twMerge(divClass, activeDragGesture === undefined ? 'transition-transform' : '', $$props.class)} use:loop={duration}>
     <slot name="slide" {Slide} {index}>
       <Slide image={images[index]} {transition} class={imgClass} />
@@ -167,4 +167,5 @@
 @prop export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
 @prop export let duration: number = 0;
 @prop export let ariaLabel: string = 'Draggable Carousel';
+@prop export let imgClass: string = '';
 -->

--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -26,6 +26,7 @@
 
   // Carousel
   let divClass: string = 'overflow-hidden relative rounded-lg h-56 sm:h-64 xl:h-80 2xl:h-96';
+  export let imgClass: string = '';
 
   const dispatch = createEventDispatcher();
 
@@ -151,7 +152,7 @@
 <div bind:this={carouselDiv} class="relative" on:mousedown={onDragStart} on:touchstart|passive={onDragStart} role="button" aria-label={ariaLabel} tabindex="0">
   <div {...$$restProps} class={twMerge(divClass, activeDragGesture === undefined ? 'transition-transform' : '', $$props.class)} use:loop={duration}>
     <slot name="slide" {Slide} {index}>
-      <Slide image={images[index]} {transition} />
+      <Slide image={images[index]} {transition} class={imgClass} />
     </slot>
   </div>
   <slot {index} {Controls} {Indicators} />

--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -2,51 +2,86 @@
   export type State = {
     images: HTMLImgAttributes[];
     index: number;
+    lastSlideChange: Date;
+    slideDuration: number; // ms
+    forward: boolean;
   };
 </script>
 
 <script lang="ts">
   import { createEventDispatcher, onMount, setContext } from 'svelte';
-  import { quintOut } from 'svelte/easing';
   import type { HTMLImgAttributes } from 'svelte/elements';
   import { writable } from 'svelte/store';
-  import { fade, type TransitionConfig } from 'svelte/transition';
+  import type { TransitionConfig } from 'svelte/transition';
   import { twMerge } from 'tailwind-merge';
   import Controls from './Controls.svelte';
   import Indicators from './Indicators.svelte';
   import Slide from './Slide.svelte';
+  import { canChangeSlide } from './Carousel';
 
   type TransitionFunc = (node: HTMLElement, params: any) => TransitionConfig;
+  const SLIDE_DURATION_RATIO = 0.25; // TODO: Expose one day?
 
   export let images: HTMLImgAttributes[];
   export let index: number = 0;
-  export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
+  export let slideDuration: number = 1000;
+  export let transition: TransitionFunc | null;
   export let duration: number = 0;
   export let ariaLabel: string = 'Draggable Carousel';
 
   // Carousel
-  let divClass: string = 'overflow-hidden relative rounded-lg h-56 sm:h-64 xl:h-80 2xl:h-96';
+  let divClass: string = 'grid overflow-hidden relative rounded-lg h-56 sm:h-64 xl:h-80 2xl:h-96';
   export let imgClass: string = '';
 
   const dispatch = createEventDispatcher();
 
-  const { set, subscribe, update } = writable<State>({ images, index });
+  const { set, subscribe, update } = writable<State>({ images, index, forward: true, slideDuration, lastSlideChange: new Date() });
 
-  const state = { set: (s: State) => set({ index: ((s.index % images.length) + images.length) % images.length, images: s.images }), subscribe, update };
+  const state = { set: (_state: State) => set({ index: _state.index, images: _state.images, lastSlideChange: new Date(), slideDuration, forward }), subscribe, update };
+
+  let forward = true;
 
   setContext('state', state);
 
-  subscribe((s) => {
-    index = s.index;
+  subscribe((_state) => {
+    index = _state.index;
+    forward = _state.forward;
     dispatch('change', images[index]);
   });
 
-  onMount(() => dispatch('change', images[index]));
+  onMount(() => {
+    dispatch('change', images[index]);
+  });
 
-  $: state.set({ images, index });
+  let prevIndex: number = index;
+  $: {
+    if (!prevIndex || prevIndex < index) {
+      update((_state) => ({ ..._state, forward: true, index }));
+    } else {
+      update((_state) => ({ ..._state, forward: false, index }));
+    }
+    prevIndex = index;
+  }
 
-  const nextSlide = () => (index += 1);
-  const prevSlide = () => (index -= 1);
+  const nextSlide = () => {
+    update((_state) => {
+      if (!canChangeSlide({ lastSlideChange: _state.lastSlideChange, slideDuration, slideDurationRatio: SLIDE_DURATION_RATIO })) return _state;
+
+      _state.index = _state.index >= images.length - 1 ? 0 : _state.index + 1;
+      _state.lastSlideChange = new Date();
+      return { ..._state };
+    });
+  };
+
+  const prevSlide = () => {
+    update((_state) => {
+      if (!canChangeSlide({ lastSlideChange: _state.lastSlideChange, slideDuration, slideDurationRatio: SLIDE_DURATION_RATIO })) return _state;
+
+      _state.index = _state.index <= 0 ? images.length - 1 : _state.index - 1;
+      _state.lastSlideChange = new Date();
+      return { ..._state };
+    });
+  };
 
   const loop = (node: HTMLElement, duration: number) => {
     carouselDiv = node; // used by DragStart
@@ -88,7 +123,7 @@
     }
   };
 
-  const onDragStart = (evt: MouseEvent | TouchEvent) => { // onDragStart must be invoked with "nonpassive" because of preventDefault
+  const onDragStart = (evt: MouseEvent | TouchEvent) => {
     touchEvent = evt;
     evt.cancelable && evt.preventDefault();
     const start = getPositionFromEvent(evt);
@@ -133,26 +168,39 @@
             } else if (percentOffset > DRAG_MIN_PERCENT) prevSlide();
             else if (percentOffset < -DRAG_MIN_PERCENT) nextSlide();
             else {
-              // The gesture is a tap not drag, so manually issue a click event to trigger tap click gestures lost via preventDefault
-              touchEvent?.target?.dispatchEvent(
-                new Event('click', {
-                  bubbles: true
-                })
-              );
+              // Only issue click event for touches
+              if (touchEvent?.constructor.name === 'TouchEvent') {
+                // The gesture is a tap not drag, so manually issue a click event to trigger tap click gestures lost via preventDefault
+                touchEvent?.target?.dispatchEvent(
+                  new Event('click', {
+                    bubbles: true
+                  })
+                );
+              }
             }
           }
+
           percentOffset = 0;
           activeDragGesture = undefined;
           touchEvent = null;
         };
 </script>
 
+<!-- Preload all Carousel images for improved responsivity -->
+<svelte:head>
+  {#if images.length > 0}
+    {#each images as image}
+      <link rel="preload" href={image.src} as="image" />
+    {/each}
+  {/if}
+</svelte:head>
+
 <!-- The move listeners go here, so things keep working if the touch strays out of the element. -->
 <svelte:document on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} />
 <div bind:this={carouselDiv} class="relative" on:mousedown|nonpassive={onDragStart} on:touchstart|nonpassive={onDragStart} on:mousemove={onDragMove} on:mouseup={onDragStop} on:touchmove={onDragMove} on:touchend={onDragStop} role="button" aria-label={ariaLabel} tabindex="0">
   <div {...$$restProps} class={twMerge(divClass, activeDragGesture === undefined ? 'transition-transform' : '', $$props.class)} use:loop={duration}>
     <slot name="slide" {Slide} {index}>
-      <Slide image={images[index]} {transition} class={imgClass} />
+      <Slide image={images[index]} class={imgClass} {transition} />
     </slot>
   </div>
   <slot {index} {Controls} {Indicators} />
@@ -164,7 +212,8 @@
 ## Props
 @prop export let images: HTMLImgAttributes[];
 @prop export let index: number = 0;
-@prop export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
+@prop export let slideDuration: number = 1000;
+@prop export let transition: TransitionFunc | null;
 @prop export let duration: number = 0;
 @prop export let ariaLabel: string = 'Draggable Carousel';
 @prop export let imgClass: string = '';

--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -89,7 +89,7 @@
 
   const onDragStart = (evt: MouseEvent | TouchEvent) => {
     touchEvent = evt;
-    evt.preventDefault();
+    evt.cancelable && evt.preventDefault();
     const start = getPositionFromEvent(evt);
     const width = carouselDiv.getBoundingClientRect().width;
     if (start === undefined || width === undefined) return;

--- a/src/lib/carousel/Carousel.ts
+++ b/src/lib/carousel/Carousel.ts
@@ -1,0 +1,16 @@
+export const canChangeSlide = ({
+  lastSlideChange,
+  slideDuration,
+  slideDurationRatio = 1,
+}: {
+  lastSlideChange: Date,
+  slideDuration: number,
+  slideDurationRatio?: number, // Allows for starting a new transition before the previous completes
+}) => {
+  if (lastSlideChange && new Date().getTime() - lastSlideChange.getTime() < slideDuration * slideDurationRatio) {
+    console.warn("Can't change slide yet, too soon");
+    return false;
+  }
+
+  return true;
+}

--- a/src/lib/carousel/Controls.svelte
+++ b/src/lib/carousel/Controls.svelte
@@ -9,7 +9,7 @@
 
   function changeSlide(forward: boolean) {
     return function (ev: Event) {
-      if (ev.isTrusted) $state.index = forward ? $state.index + 1 : $state.index - 1;
+      $state.index = forward ? $state.index + 1 : $state.index - 1;
     };
   }
 </script>

--- a/src/lib/carousel/Controls.svelte
+++ b/src/lib/carousel/Controls.svelte
@@ -4,18 +4,42 @@
   import type { State } from './Carousel.svelte';
   import ControlButton from './ControlButton.svelte';
   import { twMerge } from 'tailwind-merge';
+  import { canChangeSlide } from './Carousel';
 
   const state = getContext<Writable<State>>('state');
+  const { update } = state;
 
   function changeSlide(forward: boolean) {
-    return function (ev: Event) {
-      $state.index = forward ? $state.index + 1 : $state.index - 1;
-    };
+    if (
+      !canChangeSlide({
+        lastSlideChange: $state.lastSlideChange,
+        slideDuration: $state.slideDuration,
+        slideDurationRatio: 0.75
+      })
+    ) {
+      return;
+    }
+
+    if (forward) {
+      update((_state) => {
+        _state.forward = true;
+        _state.index = _state.index >= _state.images.length - 1 ? 0 : _state.index + 1;
+        _state.lastSlideChange = new Date();
+        return { ..._state };
+      });
+    } else {
+      update((_state) => {
+        _state.forward = false;
+        _state.index = _state.index <= 0 ? _state.images.length - 1 : _state.index - 1;
+        _state.lastSlideChange = new Date();
+        return { ..._state };
+      });
+    }
   }
 </script>
 
 <!-- Slider controls -->
 <slot {ControlButton} {changeSlide}>
-  <ControlButton name="Previous" forward={false} on:click={changeSlide(false)} class={twMerge($$props.class)} />
-  <ControlButton name="Next" forward={true} on:click={changeSlide(true)} class={twMerge($$props.class)} />
+  <ControlButton name="Previous" forward={false} on:click={() => changeSlide(false)} class={twMerge($$props.class)} />
+  <ControlButton name="Next" forward={true} on:click={() => changeSlide(true)} class={twMerge($$props.class)} />
 </slot>

--- a/src/lib/carousel/Controls.svelte
+++ b/src/lib/carousel/Controls.svelte
@@ -3,7 +3,7 @@
   import type { Writable } from 'svelte/store';
   import type { State } from './Carousel.svelte';
   import ControlButton from './ControlButton.svelte';
-  import { twJoin } from 'tailwind-merge';
+  import { twMerge } from 'tailwind-merge';
 
   const state = getContext<Writable<State>>('state');
 
@@ -16,6 +16,6 @@
 
 <!-- Slider controls -->
 <slot {ControlButton} {changeSlide}>
-  <ControlButton name="Previous" forward={false} on:click={changeSlide(false)} class={twJoin($$props.class)} />
-  <ControlButton name="Next" forward={true} on:click={changeSlide(true)} class={twJoin($$props.class)} />
+  <ControlButton name="Previous" forward={false} on:click={changeSlide(false)} class={twMerge($$props.class)} />
+  <ControlButton name="Next" forward={true} on:click={changeSlide(true)} class={twMerge($$props.class)} />
 </slot>

--- a/src/lib/carousel/Slide.svelte
+++ b/src/lib/carousel/Slide.svelte
@@ -9,7 +9,6 @@
   export let image: HTMLImgAttributes;
   export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
 
-  let imgClass: string;
   $: imgClass = twMerge('absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2 object-cover', $$props.class);
 </script>
 

--- a/src/lib/carousel/Slide.svelte
+++ b/src/lib/carousel/Slide.svelte
@@ -1,25 +1,51 @@
 <script lang="ts">
-  import { quintOut } from 'svelte/easing';
   import type { HTMLImgAttributes } from 'svelte/elements';
-  import { fade, type TransitionConfig } from 'svelte/transition';
+  import { fly, type TransitionConfig } from 'svelte/transition';
   import { twMerge } from 'tailwind-merge';
+  import { getContext } from 'svelte';
+  import type { Writable } from 'svelte/store';
+  import type { State } from './Carousel.svelte';
+
+  const state = getContext<Writable<State>>('state');
 
   type TransitionFunc = (node: HTMLElement, params: any) => TransitionConfig;
 
   export let image: HTMLImgAttributes;
-  export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
+  export let transition: TransitionFunc | null = null; // Optional transition function, overrides default slide transition
 
-  $: imgClass = twMerge('absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2 object-cover', $$props.class);
+  $: transitionSlideIn = {
+    x: $state.forward ? '100%' : '-100%',
+    opacity: 1,
+    width: '100%',
+    height: '100%',
+    duration: $state.slideDuration
+  };
+
+  $: transitionSlideOut = {
+    x: $state.forward ? '-100%' : '100%',
+    opacity: 0.9,
+    width: '100%',
+    height: '100%',
+    duration: $state.slideDuration
+  };
+
+  $: imgClass = twMerge('absolute block !w-full h-full object-cover', $$props.class);
 </script>
 
-{#key image}
-  <img alt="..." {...image} transition:transition={{}} {...$$restProps} class={imgClass} />
-{/key}
+{#if transition}
+  {#key image}
+    <img alt="..." {...image} transition:transition={{}} {...$$restProps} class={imgClass} />
+  {/key}
+{:else}
+  {#key image}
+    <img alt="..." {...image} {...$$restProps} out:fly={transitionSlideOut} in:fly={transitionSlideIn} class={imgClass} />
+  {/key}
+{/if}
 
 <!--
 @component
 [Go to docs](https://flowbite-svelte.com/)
 ## Props
 @prop export let image: HTMLImgAttributes;
-@prop export let transition: TransitionFunc = (x) => fade(x, { duration: 700, easing: quintOut });
+@prop export let transition: TransitionFunc | null = null;
 -->

--- a/src/lib/carousel/Thumbnails.svelte
+++ b/src/lib/carousel/Thumbnails.svelte
@@ -6,6 +6,7 @@
   export let images: HTMLImgAttributes[] = [];
   export let index: number = 0;
   export let ariaLabel: string = 'Click to view image';
+  export let imgClass: string = '';
 
   $: index = (index + images.length) % images.length;
 </script>
@@ -15,8 +16,8 @@
     {@const selected = index === idx}
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <button on:click={() => (index = idx)} aria-label={ariaLabel}>
-      <slot {Thumbnail} {image} {selected}>
-        <Thumbnail {...image} {selected} />
+      <slot {Thumbnail} {image} {selected} {imgClass}>
+        <Thumbnail {...image} {selected} class={imgClass} />
       </slot>
     </button>
   {/each}
@@ -29,4 +30,5 @@
 @prop export let images: HTMLImgAttributes[] = [];
 @prop export let index: number = 0;
 @prop export let ariaLabel: string = 'Click to view image';
+@prop export let imgClass:string = '';
 -->

--- a/src/lib/carousel/Thumbnails.svelte
+++ b/src/lib/carousel/Thumbnails.svelte
@@ -7,6 +7,22 @@
   export let index: number = 0;
   export let ariaLabel: string = 'Click to view image';
   export let imgClass: string = '';
+  export let throttleDelay: number = 650; // ms
+
+  let lastClickedAt = new Date();
+
+  const btnClick = (idx: number) => {
+    if (new Date().getTime() - lastClickedAt.getTime() < throttleDelay) {
+      console.warn('Thumbnail action throttled');
+      return;
+    }
+    if (idx === index) {
+      return;
+    }
+
+    index = idx;
+    lastClickedAt = new Date();
+  };
 
   $: index = (index + images.length) % images.length;
 </script>
@@ -15,7 +31,7 @@
   {#each images as image, idx}
     {@const selected = index === idx}
     <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <button on:click={() => (index = idx)} aria-label={ariaLabel}>
+    <button on:click={() => btnClick(idx)} aria-label={ariaLabel}>
       <slot {Thumbnail} {image} {selected} {imgClass}>
         <Thumbnail {...image} {selected} class={imgClass} />
       </slot>
@@ -30,5 +46,6 @@
 @prop export let images: HTMLImgAttributes[] = [];
 @prop export let index: number = 0;
 @prop export let ariaLabel: string = 'Click to view image';
-@prop export let imgClass:string = '';
+@prop export let imgClass: string = '';
+@prop export let throttleDelay: number = 650;
 -->

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -196,9 +196,9 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
 </script>
 
 <div class="max-w-4xl space-y-4">
-  <Carousel {images} let:Indicators let:Controls class="rounded-none ring-4 ring-green-500 border-4 border-white dark:border-gray-800">
+  <Carousel {images} imgClass="object-contain h-full w-fit rounded-sm" let:Indicators let:Controls class="rounded-md ring-4 ring-green-500 border-4 border-white dark:border-gray-800 min-h-[320px] bg-gray-200">
     <Indicators class="border border-white rounded-md p-2" />
-    <Controls class="items-start text-red-400 dark:text-green-400 pt-4" />
+    <Controls class="items-center text-red-400 dark:text-green-400 pt-4" />
   </Carousel>
 </div>
 ```
@@ -214,7 +214,7 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
 </script>
 
 <div class="max-w-4xl space-y-4">
-  <Carousel {images} class="min-h-[320px]" imgClass="object-contain !h-full" let:Indicators let:Controls bind:index>
+  <Carousel {images} let:Indicators let:Controls bind:index>
     <Indicators let:selected let:index>
       <Indicator color={selected ? 'red' : 'green'} class="w-5 h-5 text-white border border-white {selected ? 'opacity-100' : 'opacity-80'}">
         {index}
@@ -226,7 +226,7 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
     </Controls>
   </Carousel>
   <Thumbnails class="bg-transparent gap-3" let:Thumbnail let:image let:selected {images} bind:index>
-    <Thumbnail {...image} {selected} class="rounded-md shadow-xl hover:outline hover:outline-primary-500" />
+    <Thumbnail {...image} {selected} class="rounded-md shadow-xl hover:outline hover:outline-primary-500" activeClass="outline outline-primary-400"/>
   </Thumbnails>
 </div>
 ```

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -129,14 +129,15 @@ You can control the `Carousel` component externally by the `index` prop. Here is
   import { images } from './imageData/+server.js';
 
   let index = 0;
+  let forward = true; // sync animation direction between Thumbnails and Carousel
 </script>
 
 <div class="max-w-4xl space-y-4">
-  <Carousel {images} let:Indicators let:Controls bind:index>
+  <Carousel {images} {forward} let:Indicators let:Controls bind:index>
     <Controls />
     <Indicators />
   </Carousel>
-  <Thumbnails {images} bind:index />
+  <Thumbnails {images} {forward} bind:index />
 </div>
 ```
 
@@ -154,6 +155,7 @@ The `Carousel` exposes the `change` event containing info about the currently di
 </script>
 
 <div class="max-w-4xl space-y-4">
+
   <Carousel {images} let:Indicators let:Controls on:change={({ detail }) => (image = detail)}>
     <Controls />
     <Indicators />
@@ -177,7 +179,7 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
 
 <div class="max-w-4xl space-y-4">
   <Carousel {images} duration={3900} let:Indicators>
-    <a slot="slide" href="http://google.com/search?q={images[index].title}" target="_blank" let:Slide let:index>
+    <a slot="slide" href="http://google.com/search?q={images[index]?.title}" target="_blank" let:Slide let:index>
       <Slide image={images[index]} />
     </a>
     <Indicators />
@@ -231,19 +233,20 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
 </div>
 ```
 
-### Carousel transition
+### Custom Carousel transition
 
 ```svelte example
 <script>
   import { Carousel } from 'flowbite-svelte';
   import { images } from './imageData/+server.js';
-  import { fly } from 'svelte/transition';
+  import { scale } from 'svelte/transition';
+  import { quintOut } from 'svelte/easing';
 
-  const myFly = (x) => fly(x, { delay: 250, duration: 900, x: 700 });
+  const scaleAnimation = (x) => scale(x, { duration: 500, easing: quintOut });
 </script>
 
 <div class="max-w-4xl">
-  <Carousel {images} transition={myFly} let:Controls let:Indicators>
+  <Carousel {images} transition={scaleAnimation} let:Controls let:Indicators>
     <Controls />
     <Indicators />
   </Carousel>

--- a/src/routes/docs/components/carousel.md
+++ b/src/routes/docs/components/carousel.md
@@ -214,9 +214,9 @@ You can use `slot="slide"` and internal component `Slide` to control the image d
 </script>
 
 <div class="max-w-4xl space-y-4">
-  <Carousel {images} let:Indicators let:Controls bind:index>
+  <Carousel {images} class="min-h-[320px]" imgClass="object-contain !h-full" let:Indicators let:Controls bind:index>
     <Indicators let:selected let:index>
-      <Indicator color={selected ? 'red' : 'green'} class="w-5 h-5  text-white border border-white {selected ? 'opacity-100' : 'opacity-80'}">
+      <Indicator color={selected ? 'red' : 'green'} class="w-5 h-5 text-white border border-white {selected ? 'opacity-100' : 'opacity-80'}">
         {index}
       </Indicator>
     </Indicators>


### PR DESCRIPTION
## 📑 Description
- Feature: Re-exposes the ability for custom image styling which was removed during the recent Carousel API update. This change now allows for tailwind classes to be passed to the `img` element inside the `Slide` component
- Bugfix: Looks like #1045 added a bug for swiping on mobile devices: `Unable to preventDefault inside passive event listener invocation`. This is an example of the error on the current Flowbite Svelte webpage:

https://github.com/themesberg/flowbite-svelte/assets/4033621/faef943b-6297-4c8a-9907-9a1fc04186cf
- Bugfix: Also, this PR fixes issues with Touch events, such as onDragStop not firing in certain environments. Touch event listeners need to also be added on the Carousel `div` element to work properly without throwing errors across different environments.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
