### PR TITLE
fix: check activateClickOutside on outside click

### DIFF
--- a/src/lib/drawer/Drawer.svelte
+++ b/src/lib/drawer/Drawer.svelte
@@ -45,6 +45,8 @@
     hidden = !hidden;
   };
 
+  const handleClickOutside = () => activateClickOutside && !hidden && handleDrawer();
+
   let backdropDivClass = twMerge('fixed top-0 left-0 z-50 w-full h-full', backdrop && bgColor, backdrop && bgOpacity);
 
   function clickOutsideWrapper(node: HTMLElement, callback: () => void) {
@@ -59,7 +61,7 @@
     <div role="presentation" class={backdropDivClass} />
   {/if}
 
-  <div use:clickOutsideWrapper={() => !hidden && handleDrawer()} {id} {...$$restProps} class={twMerge(divClass, width, position, placements[placement], $$props.class)} transition:multiple={transitionParams} tabindex="-1" aria-controls={id} aria-labelledby={id}>
+  <div use:clickOutsideWrapper={handleClickOutside} {id} {...$$restProps} class={twMerge(divClass, width, position, placements[placement], $$props.class)} transition:multiple={transitionParams} tabindex="-1" aria-controls={id} aria-labelledby={id}>
     <slot {hidden} />
   </div>
 {/if}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1080

## 📑 Description

This PR introduces a check in the Drawer component which allows changing the value of `activateClickOutside` after the component is mounted.
This is done by adding `activateClickOutside` as a condition inside the function called by `clickOutsideWrapper`.
<!-- Add a brief description of the PR -->

## Status

- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] ~I have updated the documentation as required~
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

This fix assumes that the behaviour is not intentional.