### PR TITLE
fix: background context should affect only dark background in Textarea

### DIFF
--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -13,7 +13,7 @@
   $: wrapped = $$slots.header || $$slots.footer;
 
   let wrapperClass: string;
-  $: wrapperClass = twMerge('w-full rounded-lg', background ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700', 'text-gray-900 dark:placeholder-gray-400 dark:text-white ', 'border border-gray-200 dark:border-gray-600', $$props.class);
+  $: wrapperClass = twMerge('w-full rounded-lg bg-gray-50', background ? 'dark:bg-gray-800' : 'dark:bg-gray-700', 'text-gray-900 dark:placeholder-gray-400 dark:text-white ', 'border border-gray-200 dark:border-gray-600', $$props.class);
 
   let textareaClass: string;
   $: textareaClass = wrapped ? wrappedClass : twMerge(wrapperClass, unWrappedClass);

--- a/src/lib/toolbar/ToolbarButton.svelte
+++ b/src/lib/toolbar/ToolbarButton.svelte
@@ -22,7 +22,7 @@
     pink: 'text-pink-500 focus:ring-pink-400 hover:bg-pink-200 dark:hover:bg-pink-800 dark:hover:text-pink-300',
     blue: 'text-blue-500 focus:ring-blue-400 hover:bg-blue-200 dark:hover:bg-blue-800 dark:hover:text-blue-300',
     primary: 'text-primary-500 focus:ring-primary-400 hover:bg-primary-200 dark:hover:bg-primary-800 dark:hover:text-primary-300',
-    default: 'focus:ring-gray-400'
+    default: 'focus:ring-gray-400 hover:bg-gray-100'
   };
 
   const sizing = {
@@ -33,7 +33,7 @@
   };
 
   let buttonClass: string;
-  $: buttonClass = twMerge('focus:outline-none whitespace-normal', sizing[size], colors[color], color === 'default' && (background ? 'hover:bg-gray-100 dark:hover:bg-gray-600' : 'hover:bg-gray-100 dark:hover:bg-gray-700'), $$props.class);
+  $: buttonClass = twMerge('focus:outline-none whitespace-normal', sizing[size], colors[color], color === 'default' && (background ? 'dark:hover:bg-gray-600' : 'dark:hover:bg-gray-700'), $$props.class);
 
   const svgSizes = {
     xs: 'w-3 h-3',


### PR DESCRIPTION
There are 7 places where `getContext('background')` is used - `Checkbox`, `Input`, `InputAddon`, `Radio`, `Textarea`, `Toggle` and `ToolbarButton`. In all of them except `Textarea` this context only slightly changes color of some aspect in dark mode. But in `Textarea` it also changes `bg-gray-50` to `bg-white`.

Removed that switch to be consistent with other components. (And in `ToolbarButton` just moved the same class from a conditional statement.)