### PR TITLE
fix: add missing types on Modal $$Props

### DIFF
--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -12,11 +12,15 @@
     open?: boolean;
     title?: string;
     size?: SizeType;
-    placement?: 'top-left' | 'top-center' | 'top-right' | 'center-left' | 'center' | 'center-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
+    placement?: ModalPlacementType;
     autoclose?: boolean;
     backdropClass?: string;
+    bodyClass?: string;
+    classBackdrop?: string;
+    classDialog?: string;
     defaultClass?: string;
     outsideclose?: boolean;
+    dialogClass?: string;
   }
 
   export let open: boolean = false;


### PR DESCRIPTION
## 📑 Description

Adds missing properties on the Modal component. This allows the use of these options when using typescript.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

The naming of `bodyClass` doesn't match the other patterns of class naming parameters. It may be good in the future to adjust this functionality and introduce a `classBody` parameter as well, so that it functions the same as other class modifiers.
