### PR TITLE
Updated ordered list example to actually use `tag="ol"`

### DIFF
--- a/src/routes/docs/typography/list.md
+++ b/src/routes/docs/typography/list.md
@@ -132,7 +132,7 @@ Use the `tag="ol"` prop to create an ordered list of items with numbers.
 </script>
 
 <Heading tag="h2" customSize="text-lg font-semibold" class="mb-2 text-lg font-semibold  text-gray-900 dark:text-white">Top students:</Heading>
-<List tag="ul" class="space-y-1 text-gray-500 dark:text-gray-400">
+<List tag="ol" class="space-y-1 text-gray-500 dark:text-gray-400">
   <Li><Span>Bonnie Green</Span> with <Span>70</Span> points</Li>
   <Li><Span>Jese Leos</Span> with <Span>63</Span> points</Li>
   <Li><Span>Leslie Livingston</Span> with <Span>57</Span> points</Li>


### PR DESCRIPTION
## 📑 Description

Updated docs ordered list example to actually use `tag="ol"`


