### PR TITLE
fix: modal divide-y instead of border

### DIFF
--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -110,6 +110,7 @@
   function handleKeys(e: KeyboardEvent) {
     if (e.key === 'Escape' && dismissable) return hide(e);
   }
+
 </script>
 
 {#if open}

--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -101,7 +101,7 @@
   };
 
   let frameClass: string;
-  $: frameClass = twMerge(defaultClass, 'w-full', $$props.class);
+  $: frameClass = twMerge(defaultClass, 'w-full divide-y', $$props.class);
 
   const isScrollable = (e: HTMLElement): boolean[] => [e.scrollWidth > e.clientWidth && ['scroll', 'auto'].indexOf(getComputedStyle(e).overflowX) >= 0, e.scrollHeight > e.clientHeight && ['scroll', 'auto'].indexOf(getComputedStyle(e).overflowY) >= 0];
 
@@ -123,7 +123,7 @@
       <Frame rounded shadow {...$$restProps} class={frameClass}>
         <!-- Modal header -->
         {#if $$slots.header || title}
-          <Frame color={$$restProps.color} class="flex justify-between items-center p-4 rounded-t border-b">
+          <Frame color={$$restProps.color} class="flex justify-between items-center p-4 rounded-t">
             <slot name="header">
               <h3 class="text-xl font-semibold {$$restProps.color ? '' : 'text-gray-900 dark:text-white'} p-0">
                 {title}
@@ -140,7 +140,7 @@
         </div>
         <!-- Modal footer -->
         {#if $$slots.footer}
-          <Frame color={$$restProps.color} class="flex items-center p-6 space-x-2 rounded-b border-t">
+          <Frame color={$$restProps.color} class="flex items-center p-6 space-x-2 rounded-b">
             <slot name="footer" />
           </Frame>
         {/if}

--- a/src/routes/docs/components/modal.md
+++ b/src/routes/docs/components/modal.md
@@ -201,60 +201,19 @@ You can use five different modal sizing options starting from extra small to ext
 ```svelte example class="flex justify-center" hideResponsiveButtons
 <script>
   import { Button, Modal } from 'flowbite-svelte';
-  let id = 'size-modal';
-  let sizesModal = false;
+  let openModal = false;
   let size;
 </script>
 
 <div class="block space-y-4 md:space-y-0 md:space-x-4">
-  <Button
-    size="xs"
-    on:click={() => {
-      id = 'extrasmall-modal';
-      size = 'xs';
-      sizesModal = true;
-    }}>
-    xs
-  </Button>
-  <Button
-    size="sm"
-    on:click={() => {
-      id = 'small-modal';
-      size = 'sm';
-      sizesModal = true;
-    }}>
-    sm
-  </Button>
-  <Button
-    size="md"
-    on:click={() => {
-      id = 'medium-modal';
-      size = 'md';
-      sizesModal = true;
-    }}>
-    md
-  </Button>
-  <Button
-    size="lg"
-    on:click={() => {
-      id = 'large-modal';
-      size = 'lg';
-      sizesModal = true;
-    }}>
-    lg
-  </Button>
-  <Button
-    size="xl"
-    on:click={() => {
-      id = 'extralarge-modal';
-      size = 'xl';
-      sizesModal = true;
-    }}>
-    xl
-  </Button>
+  <Button size="xs" on:click={() => { size = 'xs'; openModal = true; }}>xs</Button>
+  <Button size="sm" on:click={() => { size = 'sm'; openModal = true; }}>sm</Button>
+  <Button size="md" on:click={() => { size = 'md'; openModal = true; }}>md</Button>
+  <Button size="lg" on:click={() => { size = 'lg'; openModal = true; }}>lg</Button>
+  <Button size="xl" on:click={() => { size = 'xl'; openModal = true; }}>xl</Button>
 </div>
 
-<Modal {id} title="Terms of Service" bind:open={sizesModal} {size} autoclose>
+<Modal title="Terms of Service" bind:open={openModal} {size} autoclose>
   <p class="text-base leading-relaxed text-gray-500 dark:text-gray-400">With less than a month to go before the European Union enacts new consumer privacy laws for its citizens, companies around the world are updating their terms of service agreements to comply.</p>
   <p class="text-base leading-relaxed text-gray-500 dark:text-gray-400">The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is meant to ensure a common set of data rights in the European Union. It requires organizations to notify users as soon as possible of high-risk data breaches that could personally affect them.</p>
   <svelte:fragment slot="footer">
@@ -312,45 +271,11 @@ You can use five different modal sizing options starting from extra small to ext
 </script>
 
 <div class="block space-y-4 md:space-y-0 md:space-x-4">
-  <Button
-    on:click={() => {
-      color = 'primary';
-      open = true;
-    }}>
-    Primary modal
-  </Button>
-  <Button
-    color="red"
-    on:click={() => {
-      color = 'red';
-      open = true;
-    }}>
-    Red modal
-  </Button>
-  <Button
-    color="green"
-    on:click={() => {
-      color = 'green';
-      open = true;
-    }}>
-    Green modal
-  </Button>
-  <Button
-    color="blue"
-    on:click={() => {
-      color = 'blue';
-      open = true;
-    }}>
-    Blue modal
-  </Button>
-  <Button
-    color="yellow"
-    on:click={() => {
-      color = 'yellow';
-      open = true;
-    }}>
-    Yellow modal
-  </Button>
+  <Button on:click={() => {color = 'primary'; open = true;}}>Primary modal</Button>
+  <Button color="red" on:click={() => { color = 'red'; open = true; }}>Red modal</Button>
+  <Button color="green" on:click={() => { color = 'green'; open = true; }}>Green modal</Button>
+  <Button color="blue" on:click={() => { color = 'blue'; open = true; }}>Blue modal</Button>
+  <Button color="yellow" on:click={() => { color = 'yellow'; open = true; }}>Yellow modal</Button>
 </div>
 
 <Modal title="Terms of Service" bind:open {color} autoclose>


### PR DESCRIPTION
## 📑 Description

`Modal`
- division lines between header, body and footer changed from `border-t` / `border-b` to `division-y` on parent
- you can now change the color of those by adding `class='division-color-value'` to `Modal`
- or remove those completely by  `class='division-y-0'` 

Minor formatting to docs made as well.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
