### PR TITLE
Menu should not be focusable and doesn't need to support events

### DIFF
--- a/src/lib/navbar/Menu.svelte
+++ b/src/lib/navbar/Menu.svelte
@@ -23,7 +23,7 @@
   }
 </script>
 
-<svg xmlns="http://www.w3.org/2000/svg" role="button" tabindex="0" width={size} height={size} class={$$props.class} {...$$restProps} aria-label={ariaLabel} fill="none" {viewBox} stroke-width="2" on:click>
+<svg xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" width={size} height={size} class={$$props.class} {...$$restProps} aria-label={ariaLabel} fill="none" {viewBox} stroke-width="2">
   {@html svgpath}
 </svg>
 


### PR DESCRIPTION
## 📑 Description

Currently the SVG image inside the NavHamburger get's focused as well. Since the Menu component doesn't need to be focused in this case, the SVG needs it's role changed and made un-focusable so that the button can retain the focus.

After focus Current:
<img width="61" alt="image" src="https://github.com/themesberg/flowbite-svelte/assets/239069/0768cc91-e480-4b04-8938-baf4cf4daebe">

After focus with MR:
<img width="61" alt="image" src="https://github.com/themesberg/flowbite-svelte/assets/239069/821ffea1-e7b4-433a-bdee-356622f351f5">


## Status

- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


