### PR TITLE
Updated list-group documentation link example to redirect to actual d…

### DIFF
--- a/src/routes/docs/components/list-group.md
+++ b/src/routes/docs/components/list-group.md
@@ -54,9 +54,9 @@ You can pass extra properties to the `<a>` element by setting the `attrs` atrrib
   import { Listgroup } from 'flowbite-svelte';
   let links = [
     { name: 'Accordions', href: '/docs/components/accordion', current: true },
-    { name: 'Alerts', href: '/docs/components/alerts' },
-    { name: 'Badges', href: '/docs/components/badges' },
-    { name: 'Breadcrumbs', href: '/docs/components/breadcrumbs', attrs: {target: '_blank'} }
+    { name: 'Alerts', href: '/docs/components/alert' },
+    { name: 'Badges', href: '/docs/components/badge' },
+    { name: 'Breadcrumbs', href: '/docs/components/breadcrumb', attrs: {target: '_blank'} }
   ];
 </script>
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description

While going over the documentation of the list-group component, I noticed that in the link example the links redirect to the plural instead of the singular, causing an `Internal Error` to be thrown.
e.g. on https://flowbite-svelte.com/docs/components/breadcrumbs

I changed the links in the example to redirect to the correct documentation pages.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->
