### PR TITLE
fix: modal outside click only on mouse down

### DIFF
--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -92,6 +92,10 @@
   const onAutoClose = (e: MouseEvent) => {
     const target: Element = e.target as Element;
     if (autoclose && target?.tagName === 'BUTTON') hide(e); // close on any button click
+  };
+
+  const onOutsideClick = (e: MouseEvent) => {
+    const target: Element = e.target as Element;
     if (outsideclose && target === e.currentTarget) hide(e); // close on click outside
   };
 
@@ -118,7 +122,7 @@
   <div class={backdropCls} />
   <!-- dialog -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} class={twMerge(dialogClass, $$props.classDialog, ...getPlacementClasses())} tabindex="-1" aria-modal="true" role="dialog">
+  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} on:mousedown={onOutsideClick} class={twMerge(dialogClass, $$props.classDialog, ...getPlacementClasses())} tabindex="-1" aria-modal="true" role="dialog">
     <div class="flex relative {sizes[size]} w-full max-h-full">
       <!-- Modal content -->
       <Frame rounded shadow {...$$restProps} class={frameClass}>

--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -94,7 +94,7 @@
     if (autoclose && target?.tagName === 'BUTTON') hide(e); // close on any button click
   };
 
-  const onOutsideClick = (e: MouseEvent) => {
+  const onOutsideClose = (e: MouseEvent) => {
     const target: Element = e.target as Element;
     if (outsideclose && target === e.currentTarget) hide(e); // close on click outside
   };
@@ -122,7 +122,7 @@
   <div class={backdropCls} />
   <!-- dialog -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} on:mousedown={onOutsideClick} class={twMerge(dialogClass, $$props.classDialog, ...getPlacementClasses())} tabindex="-1" aria-modal="true" role="dialog">
+  <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} on:mousedown={onOutsideClose} class={twMerge(dialogClass, $$props.classDialog, ...getPlacementClasses())} tabindex="-1" aria-modal="true" role="dialog">
     <div class="flex relative {sizes[size]} w-full max-h-full">
       <!-- Modal content -->
       <Frame rounded shadow {...$$restProps} class={frameClass}>


### PR DESCRIPTION
## 📑 Description

### Problem:
Modal closes on mouse up (when a click outside modal is released)

### Solution:
Listen to mousedown instead click and handle outsideclose 

## Status
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).