### PR TITLE
Radio group prop bug fix.

### DIFF
--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -28,7 +28,7 @@
   export let color: FormColorType = 'primary';
   export let custom: boolean = false;
   export let inline: boolean = false;
-  export let group: number | string = '';
+  export let group: number | string | undefined = undefined;
   export let value: number | string = '';
 
   // tinted if put in component having its own background


### PR DESCRIPTION
Closes #1219

## 📑 Description

The radio form component has a prop called group. This is a svelte-specific prop that lets you bind to the value of the selected radio element. The prop is currently exported default as an empty string. The group being an empty string for all radio elements causes some weird overrides of the expected behavior like shown in #1219.

My solution is to simply set the default to undefined instead of an empty string because then it works with svelte as expected. I tried null and that caused some bugs too so undefined seems like the only correct value.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

The npm tests won't run on my computer and I can't figure out why. It is probably something simple though as I don't have any experience with playwright.
