### PR TITLE
feat: add drag and drop event handlers to TableBodyRow

### DIFF
--- a/src/lib/table/TableBodyRow.svelte
+++ b/src/lib/table/TableBodyRow.svelte
@@ -3,6 +3,9 @@
   import { getContext } from 'svelte';
 
   export let color: 'blue' | 'green' | 'red' | 'yellow' | 'purple' | 'default' | 'custom' = getContext('color');
+  export let draggable: 'true' | 'false' = 'false';
+
+  $: draggableBoolean = draggable === 'true';
 
   const colors = {
     default: 'bg-white dark:bg-gray-800 dark:border-gray-700',
@@ -38,7 +41,7 @@
   $: trClass = twMerge([!getContext('noborder') && 'border-b last:border-b-0', colors[color], getContext('hoverable') && hoverColors[color], getContext('striped') && stripColors[color], $$props.class]);
 </script>
 
-<tr {...$$restProps} class={trClass} on:click on:contextmenu on:dblclick>
+<tr {...$$restProps} class={trClass} on:click on:contextmenu on:dblclick draggable={draggableBoolean} on:drag on:dragend on:dragenter on:dragleave on:dragover on:dragstart on:drop>
   <slot />
 </tr>
 
@@ -47,4 +50,5 @@
 [Go to docs](https://flowbite-svelte.com/)
 ## Props
 @prop export let color: 'blue' | 'green' | 'red' | 'yellow' | 'purple' | 'default' | 'custom' = getContext('color');
+@prop export let draggable: 'true' | 'false' = 'false';
 -->


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description

Add Drag and Drop event handlers to `TableBodyRow.svel` to allow drag and dropping rows in a Table.


You can use it like:

```
{#each items as item, index}
    <TableBodyRow
        draggable="true"
        on:dragstart={(event) => handleDragStart(event, index)}
        on:drop={(event) => handleDrop(event, index)}
        on:dragover={handleDragOver}
    >
        ...
    </TableBodyRow>
{/each}
```

## Status

- [x] Not Completed
- [ ] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
