### PR TITLE
Fix: <Pagination> buttons stuck in dark theme

### DIFF
--- a/src/lib/pagination/Pagination.svelte
+++ b/src/lib/pagination/Pagination.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <nav aria-label={ariaLabel}>
-  <ul class={twMerge(ulClass, table && 'divide-x rtl:divide-x-reverse dark divide-gray-700 dark:divide-gray-700', $$props.class)}>
+  <ul class={twMerge(ulClass, table && 'divide-x rtl:divide-x-reverse divide-gray-300 dark:divide-gray-700', $$props.class)}>
     <li>
       <PaginationItem {large} on:click={previous} {normalClass} class={table ? 'rounded-l' : 'rounded-s-lg'}>
         <slot name="prev">Previous</slot>


### PR DESCRIPTION
Fixes regression from a5cd87a2bfed6ce25c39969be40

current:
<img width="673" alt="ss 2024-03-10 at 16 43 09@2x" src="https://github.com/themesberg/flowbite-svelte/assets/1146921/2222846b-8e00-4d20-b0a6-e935f9582169">

expected:
<img width="397" alt="ss 2024-03-10 at 17 32 17@2x" src="https://github.com/themesberg/flowbite-svelte/assets/1146921/1acca0dc-b024-4b10-bec4-0d25cb44b036">

In lieu of just removing the class and or reverting completely, i tried to figure out what happened so i could restore that code… but,
since it wasn't an outright regression nor a granular documented change, it was pretty unclear to me what the original intent was so I checked [what Flowbite uses](https://flowbite.com/docs/components/pagination/)[^0] and reverted the base lightness accordingly to 300 

it did occur to me that it was possibly an intended change to have the buttons dark always… there are some styles like that alongside "light" mode tables. however if this was the case, it should be implemented differently as the dark class cannot be overridden at the pagination container level which makes workaround and customization tedious- which is surely not the original intent, of course.



[^0]: the color shades (300/700) are the same although Flowbite relies on border-color instead of divide-[color]