### PR TITLE
DRY types from interface $$Props for Accordion.svelte

### DIFF
--- a/src/lib/accordion/Accordion.svelte
+++ b/src/lib/accordion/Accordion.svelte
@@ -26,11 +26,11 @@
     classInactive?: string;
   }
 
-  export let multiple: boolean = false;
-  export let flush: boolean = false;
-  export let activeClass: string = 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800';
-  export let inactiveClass: string = 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:dark:bg-gray-800';
-  export let defaultClass: string = 'text-gray-500 dark:text-gray-400';
+  export let multiple: $$Props['multiple'] = false;
+  export let flush: $$Props['flush'] = false;
+  export let activeClass: $$Props['activeClass'] = 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800';
+  export let inactiveClass: $$Props['inactiveClass'] = 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:dark:bg-gray-800';
+  export let defaultClass: $$Props['defaultClass'] = 'text-gray-500 dark:text-gray-400';
 
   const ctx: AccordionCtxType = {
     flush,


### PR DESCRIPTION
Hey there, I'm new to Typescript and just wondering why you don't structure your type usage more like what I'm showing in the changed PR code. Just curious—Hope you can help me understand and share your opinion why the current way is best!

Thanks!