### PR TITLE
radio/checkbox: spacing only when label is on

### DIFF
--- a/src/lib/forms/Checkbox.svelte
+++ b/src/lib/forms/Checkbox.svelte
@@ -12,7 +12,7 @@
   export let group: (string | number)[] = [];
   export let value: string | number = 'on';
   export let checked: boolean | undefined = undefined;
-  export let spacing: string = 'me-2';
+  export let spacing: string = $$slots.default ? 'me-2' : '';
 
   // tinted if put in component having its own background
   let background: boolean = getContext('background');

--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -29,7 +29,7 @@
   export let inline: boolean = false;
   export let group: number | string | undefined = undefined;
   export let value: number | string = '';
-  export let spacing: string = 'mr-2';
+  export let spacing: string = $$slots.default ? 'me-2' : '';
 
   // tinted if put in component having its own background
   let background: boolean = getContext('background');

--- a/src/routes/docs/forms/checkbox.md
+++ b/src/routes/docs/forms/checkbox.md
@@ -333,7 +333,7 @@ Use this example of an advanced layout of checkbox elements where the label pare
   <Checkbox bind:group value={2}>Two</Checkbox>
   <Checkbox bind:group value={3}>Three</Checkbox>
 </div>
-<div class="my-2 border border-gray-200 dark:border-gray-700 rounded-lg p-2 w-44">Group: {group}</div>
+<div class="my-2 border border-gray-200 dark:border-gray-700 rounded-lg p-2 w-44 dark:text-gray-400">Group: {group}</div>
 <Button on:click={() => (group.length = 0)}>Clear</Button>
 ```
 


### PR DESCRIPTION
## 📑 Description

Spacing for `Radio` and `Checkbox` is valid only when the ones are wrapped with `Label`.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
