### PR TITLE
slot for the main button

### DIFF
--- a/src/lib/speed-dial/SpeedDial.svelte
+++ b/src/lib/speed-dial/SpeedDial.svelte
@@ -38,25 +38,27 @@
 </script>
 
 <div class={divClass}>
-  {#if gradient}
-    <GradientButton {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="!p-3">
-      <slot name="icon">
-        <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-        </svg>
-      </slot>
-      <span class="sr-only">{name}</span>
-    </GradientButton>
-  {:else}
-    <Button {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="!p-3">
-      <slot name="icon">
-        <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-        </svg>
-      </slot>
-      <span class="sr-only">{name}</span>
-    </Button>
-  {/if}
+  <slot name="button">
+    {#if gradient}
+      <GradientButton {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="!p-3">
+        <slot name="icon">
+          <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          </svg>
+        </slot>
+        <span class="sr-only">{name}</span>
+      </GradientButton>
+    {:else}
+      <Button {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="!p-3">
+        <slot name="icon">
+          <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          </svg>
+        </slot>
+        <span class="sr-only">{name}</span>
+      </Button>
+    {/if}
+  </slot>
   <Popper {id} {trigger} arrow={false} color="none" activeContent {placement} class={poperClass} bind:open>
     <slot />
   </Popper>

--- a/src/routes/docs/components/speed-dial.md
+++ b/src/routes/docs/components/speed-dial.md
@@ -503,6 +503,34 @@ Use the `open` property to control the state of the popup menu.
 
 The default trigger type is hover for each speed dial component.
 
+## Custom main button
+
+You can change the main button to any element you want by using the `slot='button'`.
+
+```svelte example class="relative h-96" hideResponsiveButtons
+<script>
+  import { SpeedDial, SpeedDialButton, Rating } from 'flowbite-svelte';
+  import { ShareNodesSolid, PrintSolid, DownloadSolid, FileCopySolid } from 'flowbite-svelte-icons';
+</script>
+
+<SpeedDial defaultClass="absolute end-6 bottom-6">
+  <Rating slot="button" total={1} rating={0.5} size={48}/>
+  <SpeedDialButton name="Share">
+    <ShareNodesSolid class="w-5 h-5" />
+  </SpeedDialButton>
+  <SpeedDialButton name="Print">
+    <PrintSolid class="w-5 h-5" />
+  </SpeedDialButton>
+  <SpeedDialButton name="Download">
+    <DownloadSolid class="w-5 h-5" />
+  </SpeedDialButton>
+  <SpeedDialButton name="Copy">
+    <FileCopySolid class="w-5 h-5" />
+  </SpeedDialButton>
+</SpeedDial>
+```
+
+
 ## Component data
 
 The component has the following props, type, and default values. See [types page](/docs/pages/typescript) for type information.


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1286

## 📑 Description

Slot added for the main button replacement.

Extra example describing it, added as well. `Custom main button`.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Speed Dial component to allow for customization of the main button using the new `slot='button'` attribute.
- **Documentation**
	- Added guidance on customizing the main button of the Speed Dial component, including examples of integrating a `Rating` component and custom icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->