### PR TITLE
build: bring back svelte 3 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "svelte": "^4.0.0"
+    "svelte": "^3.55.1 || ^4.0.0"
   },
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Closes #1304

## 📑 Description

This PR brings back Svelte v3 peer dependency which allows for this library to be used in Svelte 3.
For more context see the issue above.

## Status

- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the app to be compatible with both versions `3.55.1` and `4.0.0` of the Svelte framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->