### PR TITLE
feat: add `imgOnly` property for `<ImagePlaceholder />` component

### DIFF
--- a/src/lib/skeleton/ImagePlaceholder.svelte
+++ b/src/lib/skeleton/ImagePlaceholder.svelte
@@ -2,23 +2,28 @@
   import { twMerge } from 'tailwind-merge';
   export let divClass: string = 'space-y-8 animate-pulse md:space-y-0 md:space-x-8 rtl:space-x-reverse md:flex md:items-center';
   export let imgHeight: string = '48';
+  export let imgOnly: boolean = false;
+
+  $: imgOnlyClass = imgOnly ? 'max-w-60' : '';
 </script>
 
-<div role="status" class={twMerge(divClass, $$props.class)}>
-  <div class="flex justify-center items-center w-full h-{imgHeight} bg-gray-300 rounded sm:w-96 dark:bg-gray-700">
+<div role="status" class={twMerge(divClass, $$props.class, imgOnlyClass)}>
+  <div class="flex justify-center items-center w-full h-{imgHeight} bg-gray-300 rounded sm:w-96 {imgOnlyClass} dark:bg-gray-700">
     <svg width="48" height="48" class="text-gray-200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" fill="currentColor" viewBox="0 0 640 512">
       <path d="M480 80C480 35.82 515.8 0 560 0C604.2 0 640 35.82 640 80C640 124.2 604.2 160 560 160C515.8 160 480 124.2 480 80zM0 456.1C0 445.6 2.964 435.3 8.551 426.4L225.3 81.01C231.9 70.42 243.5 64 256 64C268.5 64 280.1 70.42 286.8 81.01L412.7 281.7L460.9 202.7C464.1 196.1 472.2 192 480 192C487.8 192 495 196.1 499.1 202.7L631.1 419.1C636.9 428.6 640 439.7 640 450.9C640 484.6 612.6 512 578.9 512H55.91C25.03 512 .0006 486.1 .0006 456.1L0 456.1z" />
     </svg>
   </div>
-  <div class="w-full">
-    <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-1/2 mb-4" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-9/12 mb-2.5" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 mb-2.5" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 mb-2.5" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-10/12 mb-2.5" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-11/12 mb-2.5" />
-    <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-9/12" />
-  </div>
+  {#if !imgOnly}
+    <div class="w-full">
+      <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-1/2 mb-4" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-9/12 mb-2.5" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 mb-2.5" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 mb-2.5" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-10/12 mb-2.5" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-11/12 mb-2.5" />
+      <div class="h-2 bg-gray-200 rounded-full dark:bg-gray-700 w-9/12" />
+    </div>
+  {/if}
   <span class="sr-only">Loading...</span>
 </div>
 
@@ -28,4 +33,5 @@
 ## Props
 @prop export let divClass: string = 'space-y-8 animate-pulse md:space-y-0 md:space-x-8 rtl:space-x-reverse md:flex md:items-center';
 @prop export let imgHeight: string = '48';
+@prop export let imgOnly: boolean = false;
 -->

--- a/src/routes/component-data/ImagePlaceholder.json
+++ b/src/routes/component-data/ImagePlaceholder.json
@@ -1,1 +1,1 @@
-{"name":"ImagePlaceholder","slots":[],"events":[],"props":[["divClass","string","'space-y-8 animate-pulse md:space-y-0 md:space-x-8 rtl:space-x-reverse md:flex md:items-center'"],["imgHeight","string","'48'"]]}
+{"name":"ImagePlaceholder","slots":[],"events":[],"props":[["divClass","string","'space-y-8 animate-pulse md:space-y-0 md:space-x-8 rtl:space-x-reverse md:flex md:items-center'"],["imgHeight","string","'48'"], ["imgOnly", "boolean", "false"]]}

--- a/src/routes/docs/components/skeleton.md
+++ b/src/routes/docs/components/skeleton.md
@@ -47,6 +47,7 @@ Use the skeleton component to indicate a loading status with placeholder element
 
 <ImagePlaceholder />
 <ImagePlaceholder imgHeight={60} class="mt-8" />
+<ImagePlaceholder imgOnly class="mt-8" />
 ```
 
 ## Video placeholder

--- a/src/routes/docs/components/skeleton.md
+++ b/src/routes/docs/components/skeleton.md
@@ -40,6 +40,8 @@ Use the skeleton component to indicate a loading status with placeholder element
 
 ## Image placeholder
 
+To display image placeholder without text, use `imgOnly` prop as seen in the following examples.
+
 ```svelte example
 <script>
   import { ImagePlaceholder } from 'flowbite-svelte';


### PR DESCRIPTION
Closes #1275 

## 📑 Description

I have added a new property called `imgOnly` that would allow user to only display image placeholder without text. I know that it has been specified https://github.com/themesberg/flowbite-svelte/issues/1275#issuecomment-1986959437 here to create an issue on another repository, but if they are going to implement that, the current approach could be updated based on that repository.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information

![image](https://github.com/themesberg/flowbite-svelte/assets/41910815/234d8fa7-361e-4808-9e8e-d6614bc109bd)

Also I've picked this one up as a good first issue. Let me know if I'm missing something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `ImagePlaceholder` component with an `imgOnly` property to provide options for image-only placeholders.
	- Updated documentation to include examples and usage of the new `imgOnly` property in the `ImagePlaceholder` component.
	- Conditionally rendered elements inside the `ImagePlaceholder` component based on the value of `imgOnly`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->