### PR TITLE
fix: add textarea on select handler

### DIFF
--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -31,7 +31,7 @@
     </div>
   {/if}
   <Wrapper show={wrapped} class={innerWrapperClass}>
-    <textarea bind:value on:blur on:change on:click on:contextmenu on:focus on:input on:keydown on:keypress on:keyup on:mouseenter on:mouseleave on:mouseover on:paste {...$$restProps} class={textareaClass} />
+    <textarea bind:value on:blur on:change on:click on:contextmenu on:focus on:input on:keydown on:keypress on:keyup on:mouseenter on:mouseleave on:mouseover on:paste on:select {...$$restProps} class={textareaClass} />
   </Wrapper>
   {#if $$slots.footer}
     <div class={headerClass(false)}>


### PR DESCRIPTION
## 📑 Description

The on:select handler is missing in the textarea to handle text selections within the actual textarea. This is useful to when using textarea as an editor for example.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a selection event handler to the textarea component, enabling new interaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->