### PR TITLE
[forms/Select] correctly initialize "selected" attribute for SSR

### DIFF
--- a/src/lib/forms/Select.svelte
+++ b/src/lib/forms/Select.svelte
@@ -25,11 +25,11 @@
 
 <select {...$$restProps} bind:value class={selectClass} on:change on:contextmenu on:input>
   {#if placeholder}
-    <option disabled selected value="">{placeholder}</option>
+    <option disabled selected={(value === undefined) ? true : undefined} value="">{placeholder}</option>
   {/if}
 
-  {#each items as { value, name }}
-    <option {value}>{name}</option>
+  {#each items as { value: itemValue, name }}
+    <option value={itemValue} selected={(itemValue === value) ? true : undefined}>{name}</option>
   {:else}
     <slot />
   {/each}


### PR DESCRIPTION
when:
```javascript
export const ssr = true
export const csr = false
```

The current implementation of `Select` has the `placeholder` option selected.
If defined, this update selects the option having a _value_ equal to the input property: `value`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for setting the `selected` attribute in dropdowns to ensure the correct option is selected based on the provided value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->