### PR TITLE
feat: Add disableSwipe prop to Carousel

### DIFF
--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -28,6 +28,7 @@
   export let transition: TransitionFunc | null = null;
   export let duration: number = 0;
   export let ariaLabel: string = 'Draggable Carousel';
+  export let disableSwipe: boolean = false;
 
   // Carousel
   let divClass: string = 'grid overflow-hidden relative rounded-lg h-56 sm:h-64 xl:h-80 2xl:h-96';
@@ -114,6 +115,8 @@
   };
 
   const onDragStart = (evt: MouseEvent | TouchEvent) => {
+    if (disableSwipe) return;
+
     touchEvent = evt;
     evt.cancelable && evt.preventDefault();
     const start = getPositionFromEvent(evt);


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1280 

## 📑 Description

Exposes a new `disableSwipe` prop, which allows control over whether or not swipe gestures are allowed to change slides within the Carousel. 

This PR is required because swiping slides interferes with scrolling gestures on mobile devices, resulting in full-screen Carousel components being unable to scroll without a border. 

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- All the tests have passed (running test throws a `FATHOM_ID` error, but testing in browser & iOS simulator works as expected)
- [x] My pull request is based on the latest commit (not the npm version).


## ℹ Additional Information

Tested on iOS Simulator with iPhone 15 Pro Max device, works as intended. Slide swiping navigation is disabled and user can scroll through the page, but taps for button clicks and slides still work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `disableSwipe` option to the carousel component, allowing users to disable swipe actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->