### PR TITLE
fix: close Dropdown on click outside in Safari

### DIFF
--- a/src/lib/utils/Popper.svelte
+++ b/src/lib/utils/Popper.svelte
@@ -151,6 +151,8 @@
       referenceEl = triggerEls[0];
     }
 
+    document.addEventListener('click', closeOnClickOutside);
+
     return () => {
       // This is onDestroy function
       triggerEls.forEach((element: HTMLElement) => {
@@ -162,8 +164,21 @@
         referenceEl.removeEventListener('focusout', hideHandler);
         referenceEl.removeEventListener('mouseleave', hideHandler);
       }
+      document.removeEventListener('click', closeOnClickOutside);
     };
   });
+
+  /**
+   * Close the popper when clicking outside of it.
+   * This is necessary to get around a bug in Safari where clicking outside of the open popper does not close it.
+   */
+  function closeOnClickOutside(event: MouseEvent) {
+    if (open) {
+      if (!event.composedPath().includes(floatingEl) && !triggerEls.some((el) => event.composedPath().includes(el))) {
+        hideHandler(event);
+      }
+    }
+  }
 
   function optional(pred: boolean, func: (ev: Event) => void) {
     return pred ? func : () => undefined;


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1237

## 📑 Description

Currently, `Dropdown` has a bug where clicking outside an open dropdown in Safari will not close it. It works in Chrome and Firefox as-is, but not Safari.

This PR adds explicit event handling to clicks on the document outside the `Popper` or its triggering elements. It checks if the click is on the floating element or its trigger(s), and if not, closes the popper using the existing `hideHandler`.

## Status

- [x] Not Completed
- [ ] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

There is an existing `clickOutside` utility, but it is not a fit for this use case. We need to check both the floating element and its triggers here, which is not possible in the existing `clickOutside` function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue in Safari where the popper would not close when clicking outside.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->