### PR TITLE
fix!: add close event to toast component

### DIFF
--- a/src/lib/toast/Toast.svelte
+++ b/src/lib/toast/Toast.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   // import type { Snippet } from 'svelte';
+  import {createEventDispatcher} from 'svelte';
   import { fade, type TransitionConfig } from 'svelte/transition';
   import { twMerge } from 'tailwind-merge';
   import { CloseButton } from '$lib';
@@ -20,6 +21,7 @@
   export let params = {};
 
   export let toastStatus: boolean = true;
+  const dispatch = createEventDispatcher();
 
   // const divCls: string =
   //   'w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800 gap-3';
@@ -94,6 +96,7 @@
         {color}
         on:click={() => {
           toastStatus = false;
+          dispatch('close');
         }}
       />
     {/if}

--- a/src/routes/component-data/Toast.json
+++ b/src/routes/component-data/Toast.json
@@ -1,1 +1,17 @@
-{"name":"Toast","slots":["icon"],"events":[],"props":[["dismissable","boolean","true"],["color","ColorVariant","'primary'"],["position","ToastPositionType","'none'"],["divClass","string","'w-full max-w-xs p-4 text-gray-500 bg-white shadow dark:text-gray-400 dark:bg-gray-800 gap-3'"],["defaultIconClass","string","'w-8 h-8'"],["contentClass","string","'w-full text-sm font-normal'"],["align","boolean","true"],["transition","TransitionFunc","fade"],["params","string","{}"],["toastStatus","boolean","true"]]}
+{
+  "name": "Toast",
+  "slots": ["icon"],
+  "events": ["on:close"],
+  "props": [
+    ["dismissable", "boolean", "true"],
+    ["color", "ColorVariant", "'primary'"],
+    ["position", "ToastPositionType", "'none'"],
+    ["divClass", "string", "'w-full max-w-xs p-4 text-gray-500 bg-white shadow dark:text-gray-400 dark:bg-gray-800 gap-3'"],
+    ["defaultIconClass", "string", "'w-8 h-8'"],
+    ["contentClass", "string", "'w-full text-sm font-normal'"],
+    ["align", "boolean", "true"],
+    ["transition", "TransitionFunc", "fade"],
+    ["params", "string", "{}"],
+    ["toastStatus", "boolean", "true"]
+  ]
+}

--- a/src/routes/docs/components/toast.md
+++ b/src/routes/docs/components/toast.md
@@ -345,6 +345,19 @@ Use the position property to position these toast components relative to the mai
   <Toast dismissable={false} position="bottom-right">Bottom right positioning.</Toast>
 </div>
 ```
+## Events
+
+You can use on:close to execute custom logic when the toast is closed. 
+
+```svelte example hideScript
+<script>
+  import { Toast } from 'flowbite-svelte';
+</script>
+
+<div class="relative h-56">
+  <Toast on:close={() => alert('Toast closed')}>Click the close button to see the event.</Toast>
+</div>
+```
 
 ## Component data
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

Closes # 1348

## 📑 Description

This PR adds an on:close event to the Toast component, allowing custom logic to be executed when the toast is closed.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 'close' event to the Toast component, allowing custom actions when the toast is closed.
- **Documentation**
  - Updated documentation to include a new section on the 'close' event for the Toast component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->