### PR TITLE
fix: typo in demo url

### DIFF
--- a/src/routes/docs/extend/flowbite-svelte-starter.md
+++ b/src/routes/docs/extend/flowbite-svelte-starter.md
@@ -16,7 +16,7 @@ description: Flowbite Svelte Starters provide all necessary components to get st
 
 <List tag="ul" class="space-y-1 my-4">
   <Li><A href="https://github.com/themesberg/flowbite-svelte">GitHub Repo</A></Li>
-  <Li><A href="https://flowbite-svelte.cpm/admin-dashboard">Demo</A></Li>
+  <Li><A href="https://flowbite-svelte.com/admin-dashboard">Demo</A></Li>
 </List>
 
 ## Flowbite Svelte starter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the demo link in the Flowbite Svelte Starters documentation to ensure users are directed to the proper site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->