### PR TITLE
fix: Inform TypeScript of 'imgClass' prop type

### DIFF
--- a/src/lib/cards/Card.svelte
+++ b/src/lib/cards/Card.svelte
@@ -19,6 +19,7 @@
     img?: string;
     padding?: SizeType | 'none';
     size?: SizeType | 'none';
+    imgClass?: string;
   }
 
   const paddings: Record<SizeType | 'none', string> = {


### PR DESCRIPTION
## 📑 Description

This patch ensures that `npm run gen:docs` generates a `Card.svelte.d.ts` file that knows `imgClass` is a valid prop.

When trying to use `Card`'s `imgClass` prop, TypeScript complains:

```
Object literal may only specify known properties, and '"imgClass"' does
not exist in type 'HTMLAnchorAttributes & ...'. ts(2353)
```

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

I could not run the tests as prescribed in `CONTRIBUTING.md`. When running `npm run test` I get the following problems:

```
❯ npm run test

> flowbite-svelte@0.46.15 test
> npm run test:integration && npm run test:unit


> flowbite-svelte@0.46.15 test:integration
> playwright test

[WebServer] x Build failed in 7.19s
[WebServer] error during build:
src/routes/+layout.server.js (1:9): "FATHOM_ID" is not exported by "virtual:$env/static/private", imported by "src/routes/+layout.server.js".
file: /Users/mdeboard/projects/flowbite-svelte/src/routes/+layout.server.js:1:9

1: import { FATHOM_ID } from '$env/static/private';
            ^
2: /** @type {import('./$types').LayoutServerLoad} \*/
3: export async function load () {
```

(FWIW I also had to install deps like `npm i --legacy-peer-deps`)

I tested this change as best I could by modifying the installed `flowbite-svelte` in my personal project, such that `node_modules/flowbite-svelte/dist/cards/Card.svelte.d.ts` has the new version of the file output by `gen:docs`. Doing this fixes the typescript complaint.

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

## ℹ Additional Information

The logic supporting `imgClass` was originally added in [this commit](https://github.com/themesberg/flowbite-svelte/commit/6ff61d2d922f8eb42161ef1bd87075226ac3122b). However, it seems like either the type info for the prop was not added, or changes within the structure of the code itself makes it so `gen:docs` does not do what the original contributor intended. Either way, this patch seems to fix the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `imgClass` property for enhanced customization of the card component's image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->