### PR TITLE
Add off state label to Toggle.svelte

### DIFF
--- a/src/lib/forms/Toggle.svelte
+++ b/src/lib/forms/Toggle.svelte
@@ -36,10 +36,11 @@
 
   let divClass: string;
 
-  $: divClass = twMerge(common, background ? 'dark:bg-gray-600 dark:border-gray-500' : 'dark:bg-gray-700 dark:border-gray-600', colors[($$restProps.color as FormColorType) ?? 'primary'], sizes[size], 'relative', $$props.classDiv);
+  $: divClass = twMerge(common, $$slots.offLabel ? "ms-3" : "", background ? 'dark:bg-gray-600 dark:border-gray-500' : 'dark:bg-gray-700 dark:border-gray-600', colors[($$restProps.color as FormColorType) ?? 'primary'], sizes[size], 'relative', $$props.classDiv);
 </script>
 
 <Checkbox custom {...$$restProps} class={$$props.class} {value} bind:checked bind:group on:click on:change>
+  <slot name="offLabel"></slot>
   <span class={divClass}></span>
   <slot></slot>
 </Checkbox>

--- a/src/routes/docs/forms/toggle.md
+++ b/src/routes/docs/forms/toggle.md
@@ -70,6 +70,19 @@ Get started with the default toggle component example as a checkbox element to r
 <Toggle size="custom" {customSize}>Custom toggle</Toggle>
 ```
 
+## Label for off state
+
+```svelte example class="flex flex-col gap-2"
+<script>
+  import { Toggle } from 'flowbite-svelte';
+</script>
+
+<Toggle>
+  <svelte:fragment slot="offLabel">dark mode</svelte:fragment>
+  light mode
+</Toggle>
+```
+
 ## Component data
 
 The component has the following props, type, and default values. See [types page](/docs/pages/typescript) for type information.
@@ -77,7 +90,7 @@ The component has the following props, type, and default values. See [types page
 ### Toggle styling
 
 - Use the `class` prop to overwrite the `Checkbox` component.
-- Use the 'classDiv`prop to overwrite the`divClass`.
+- Use the `classDiv` prop to overwrite the `divClass`.
 
 <CompoAttributesViewer {components}/>
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1413 

## 📑 Description

- Adds a `offLabel` slot to the Toggle component

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the Toggle component by adding a customizable "offLabel" slot for improved flexibility and usability.
	- Updated styling logic to provide additional spacing when the "offLabel" is used.
  
- **Documentation**
	- Added a new example in the documentation demonstrating how to set a label for the "off" state of the Toggle component.
	- Made minor corrections to improve the clarity of the documentation regarding the `classDiv` prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->