### PR TITLE
Add customizable placeholder feature to Avatar component

### DIFF
--- a/src/lib/avatar/Avatar.svelte
+++ b/src/lib/avatar/Avatar.svelte
@@ -3,6 +3,8 @@
   import { twMerge } from 'tailwind-merge';
 
   export let src: string = '';
+  export let fallbackSrc: string = ''; // Default fallback image
+  export let onError: boolean = true; // Control whether to handle the error event
   export let href: string | undefined = undefined;
   export let rounded: boolean = false;
   export let border: boolean = false;
@@ -23,16 +25,38 @@
   };
 
   let avatarClass: string;
-  $: avatarClass = twMerge(rounded ? 'rounded' : 'rounded-full', border && 'p-1 ring-2 ring-gray-300 dark:ring-gray-500', sizes[size], stacked && 'border-2 -ms-4 border-white dark:border-gray-800', 'bg-gray-100 dark:bg-gray-600 text-gray-600 dark:text-gray-300 object-cover', $$props.class);
+  $: avatarClass = twMerge(
+    rounded ? 'rounded' : 'rounded-full',
+    border && 'p-1 ring-2 ring-gray-300 dark:ring-gray-500',
+    sizes[size],
+    stacked && 'border-2 -ms-4 border-white dark:border-gray-800',
+    'bg-gray-100 dark:bg-gray-600 text-gray-600 dark:text-gray-300 object-cover',
+    $$props.class
+  );
+
+  // Reactive variable to manage the image source
+  let imageSrc: string = src;
+
+  // Error handler function to switch to the fallback image
+  const handleError = (event: Event) => {
+    if (onError) {
+      imageSrc = fallbackSrc;
+    }
+  };
 </script>
 
 {#if !src || !!href || $$slots.default || dot}
   <svelte:element this={href ? 'a' : 'div'} {href} {...$$restProps} class="relative flex justify-center items-center {avatarClass}">
-    {#if src}
-      <img {alt} {src} class={rounded ? 'rounded' : 'rounded-full'} />
+    {#if imageSrc}
+      <img
+        {alt}
+        src={imageSrc}
+        class={rounded ? 'rounded' : 'rounded-full'}
+        on:error={handleError}
+      />
     {:else}
       <slot>
-        <!-- default avatar placeholder -->
+        <!-- Default avatar placeholder SVG -->
         <svg class="w-full h-full {rounded ? 'rounded' : 'rounded-full'}" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M8 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
         </svg>
@@ -43,19 +67,11 @@
     {/if}
   </svelte:element>
 {:else}
-  <img {alt} {src} {...$$restProps} class={avatarClass} />
+  <img
+    {alt}
+    src={imageSrc}
+    {...$$restProps}
+    class={avatarClass}
+    on:error={handleError}
+  />
 {/if}
-
-<!--
-@component
-[Go to docs](https://flowbite-svelte.com/)
-## Props
-@prop export let src: string = '';
-@prop export let href: string | undefined = undefined;
-@prop export let rounded: boolean = false;
-@prop export let border: boolean = false;
-@prop export let stacked: boolean = false;
-@prop export let dot: object | undefined = undefined;
-@prop export let alt: string = '';
-@prop export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'none' = 'md';
--->

--- a/src/lib/avatar/Avatar.svelte
+++ b/src/lib/avatar/Avatar.svelte
@@ -75,3 +75,18 @@
     on:error={handleError}
   />
 {/if}
+
+
+<!--
+@component
+[Go to docs](https://flowbite-svelte.com/)
+## Props
+@prop export let src: string = '';
+@prop export let href: string | undefined = undefined;
+@prop export let rounded: boolean = false;
+@prop export let border: boolean = false;
+@prop export let stacked: boolean = false;
+@prop export let dot: object | undefined = undefined;
+@prop export let alt: string = '';
+@prop export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'none' = 'md';
+-->

--- a/src/routes/docs/components/avatar.md
+++ b/src/routes/docs/components/avatar.md
@@ -5,7 +5,7 @@ breadcrumb_title: Svelte Avatar
 component_title: Avatar
 dir: Components
 description: Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes
-thumbnailSize: w-64
+thumnailSize: w-64
 ---
 
 <script>

--- a/src/routes/docs/components/avatar.md
+++ b/src/routes/docs/components/avatar.md
@@ -211,7 +211,7 @@ Preset values are equivalents of:
 
 ## Customizable Placeholder
 
-This new feature allows you to customize the placeholder avatar by providing a custom `fallbackSrc` image. This is useful when you want a specific placeholder image to show when the main avatar image fails to load.
+This feature allows you to customize the placeholder avatar by providing a custom `fallbackSrc` image. This is useful when you want a specific placeholder image to show when the main avatar image fails to load.
 
 ```svelte example class="flex justify-center gap-4" hideScript hideResponsiveButtons
 <script>

--- a/src/routes/docs/components/avatar.md
+++ b/src/routes/docs/components/avatar.md
@@ -5,14 +5,14 @@ breadcrumb_title: Svelte Avatar
 component_title: Avatar
 dir: Components
 description: Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes
-thumnailSize: w-64
+thumbnailSize: w-64
 ---
 
 <script>
-  import { CompoAttributesViewer, GitHubCompoLinks, toKebabCase } from '../../utils'
-  import { P, A } from '$lib'
+  import { CompoAttributesViewer, GitHubCompoLinks, toKebabCase } from '../../utils';
+  import { P, A } from '$lib';
   let name;
-  const dirName = toKebabCase(component_title)
+  const dirName = toKebabCase(component_title);
 </script>
 
 The avatar component can be used as a visual identifier for a user profile on your website and you can use the examples from Flowbite to modify the styles and sizes of these components using the utility classes from Tailwind CSS.
@@ -44,9 +44,7 @@ Use this example to create a circle and rounded avatar on an image element.
 
 ## Bordered
 
-You can apply a border around the avatar component.
-
-If you can use the `ring-&#123;color&#125;` class from Tailwind CSS to modify ring color.
+You can apply a border around the avatar component. Use the `ring-&#123;color&#125;` class from Tailwind CSS to modify ring color.
 
 ```svelte example class="flex justify-center gap-4" hideScript hideResponsiveButtons
 <script>
@@ -103,7 +101,7 @@ Use this example to show a tooltip when hovering over the avatar.
 
 ## Dot indicator
 
-Use a dot element relative to the avatar component as an indicator for the user (eg. online or offline status).
+Use a dot element relative to the avatar component as an indicator for the user (e.g., online or offline status).
 
 ```svelte example class="flex justify-center gap-4" hideResponsiveButtons
 <script>
@@ -184,7 +182,7 @@ Use this example if you want to show a dropdown menu when clicking on the avatar
 
 ## Sizes
 
-You can set `size` property to preset values of `xs | sm | md | lg | xl`. Custom size can be achieved by setting size to `none` and adding any of the Tailwind Css size classes like `w-[x] h-[x]`.
+You can set the `size` property to preset values of `xs | sm | md | lg | xl`. Custom size can be achieved by setting size to `none` and adding any of the Tailwind CSS size classes like `w-[x] h-[x]`.
 
 Preset values are equivalents of:
 
@@ -201,7 +199,7 @@ Preset values are equivalents of:
   import { Avatar } from 'flowbite-svelte';
 </script>
 
-<div class=" flex flex-wrap justify-center space-x-4 rtl:space-x-reverse">
+<div class="flex flex-wrap justify-center space-x-4 rtl:space-x-reverse">
   <Avatar src="/images/profile-picture-3.webp" rounded size="xs" />
   <Avatar src="/images/profile-picture-3.webp" rounded size="sm" />
   <Avatar src="/images/profile-picture-3.webp" rounded size="md" />
@@ -209,6 +207,19 @@ Preset values are equivalents of:
   <Avatar src="/images/profile-picture-3.webp" rounded size="xl" />
   <Avatar src="/images/profile-picture-3.webp" rounded size="none" class="w-28 h-28" />
 </div>
+```
+
+## Customizable Placeholder
+
+This new feature allows you to customize the placeholder avatar by providing a custom `fallbackSrc` image. This is useful when you want a specific placeholder image to show when the main avatar image fails to load.
+
+```svelte example class="flex justify-center gap-4" hideScript hideResponsiveButtons
+<script>
+  import { Avatar } from 'flowbite-svelte';
+</script>
+
+<Avatar src="/images/profile-picture-3.webp" fallbackSrc="/images/fallback-picture.webp" />
+<Avatar fallbackSrc="/images/fallback-picture.webp" />
 ```
 
 ## Component data


### PR DESCRIPTION
This pull request introduces the `fallbackSrc` prop to the Avatar component, allowing for customizable placeholder images when the main image fails to load. It also updates the documentation with examples of the new feature and revises the Svelte code to handle fallback image display.

---

**Status:**

- [ ] Not Completed
- [x] Completed

**Checks:**

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

**Additional Information:**

This update enhances the Avatar component by providing an option to specify a fallback image. It is useful for scenarios where a default placeholder image is preferred if the main image fails to load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a fallback image feature for the Avatar component, enhancing user experience when the primary image fails to load.
	- Added customizable placeholder support, allowing users to specify a custom fallback image.

- **Documentation**
	- Updated documentation for the Avatar component to include new features and improve clarity on usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->