### PR TITLE
fix: #1435 Avoid double taps on buttons with tooltip on safari iOS

### DIFF
--- a/src/lib/speed-dial/SpeedDial.svelte
+++ b/src/lib/speed-dial/SpeedDial.svelte
@@ -46,7 +46,7 @@
   setContext<SpeedCtxType>('speed-dial', { pill, tooltip, textOutside });
 
   let divClass: string;
-  $: divClass = twMerge(defaultClass, 'group', $$props.class);
+  $: divClass = twMerge(defaultClass, $$props.class);
 
   let poperClass: string;
   $: poperClass = twMerge(popperDefaultClass, ['top', 'bottom'].includes(placement.split('-')[0]) && 'flex-col');
@@ -57,7 +57,7 @@
     {#if gradient}
       <GradientButton {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="p-3!">
         <slot name="icon">
-          <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <svg aria-hidden="true" class="w-8 h-8 transition-transform" class:rotate-45={open} fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
           </svg>
         </slot>
@@ -66,7 +66,7 @@
     {:else}
       <Button {pill} {name} aria-controls={id} aria-expanded={open} {...$$restProps} class="p-3!">
         <slot name="icon">
-          <svg aria-hidden="true" class="w-8 h-8 transition-transform group-hover:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <svg aria-hidden="true" class="w-8 h-8 transition-transform" class:rotate-45={open} fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
           </svg>
         </slot>

--- a/src/routes/docs/components/tooltip.md
+++ b/src/routes/docs/components/tooltip.md
@@ -104,12 +104,14 @@ The positioning of the tooltip element relative to the triggering element (eg. b
 ```svelte example class="flex items-end gap-2 h-32" hideResponsiveButtons
 <script>
   import { Tooltip, Button } from 'flowbite-svelte';
+  let actions = "";
 </script>
 
-<Button id="hover">Tooltip hover</Button>
-<Button id="click">Tooltip click</Button>
+<Button id="hover" on:click={() => (actions = "Clicked Hover-Tooltip Button\n" + actions)}>Tooltip hover</Button>
+<Button id="click" on:click={() => (actions = "Clicked Click-Tooltip Button\n" + actions)}>Tooltip click</Button>
 <Tooltip triggeredBy="#hover">Hover tooltip content</Tooltip>
 <Tooltip trigger="click" triggeredBy="#click">Click tooltip content</Tooltip>
+<pre style="height: 4rem; overflow:hidden;">{actions}</pre>
 ```
 
 ## Disable arrow


### PR DESCRIPTION
Due to an Safari Issue the first "mouseenter" event will block the "click" event. This can be worked around by using the "pointerenter" instead.

Closes #1435

## 📑 Description

As described [here](https://github.com/sveltejs/svelte/issues/13339#issuecomment-2363992564) instead of
"mouseenter" the event "pointerenter" should be used to ensure correct behaviour on iOS-

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).


## ℹ Additional Information

nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced popper interactions by updating event handling for mouse actions, improving responsiveness to various pointer events.
	- Introduced a customizable `closeOnTouchDelay` property for the popper, allowing users to define how long the popper remains open on touch devices.
	- Updated the speed dial button's rotation behavior to be directly tied to its open state, enhancing visual feedback during interactions.
	- Added a log of user interactions with tooltip buttons, displaying a history of clicks for better user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->