### PR TITLE
fix: change github repo link for admin dashboard in extend section

### DIFF
--- a/src/routes/docs/extend/flowbite-svelte-starter.md
+++ b/src/routes/docs/extend/flowbite-svelte-starter.md
@@ -15,7 +15,7 @@ description: Flowbite Svelte Starters provide all necessary components to get st
 ## Flowbite Svelte Admin Dashboard
 
 <List tag="ul" class="space-y-1 my-4">
-  <Li><A href="https://github.com/themesberg/flowbite-svelte">GitHub Repo</A></Li>
+  <Li><A href="https://github.com/themesberg/flowbite-svelte-admin-dashboard">GitHub Repo</A></Li>
   <Li><A href="https://flowbite-svelte.com/admin-dashboard">Demo</A></Li>
 </List>
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description

Link in extend section for admin dashboard pointed to flowbite-svelte repository.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated hyperlink in the Flowbite Svelte Admin Dashboard section to direct users to the correct GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->