### PR TITLE
Make it easier to see if controls are disabled

### DIFF
--- a/src/lib/forms/Helper.svelte
+++ b/src/lib/forms/Helper.svelte
@@ -6,7 +6,7 @@
     gray: 'text-gray-900 dark:text-gray-300',
     green: 'text-green-700 dark:text-green-500',
     red: 'text-red-700 dark:text-red-500',
-    disabled: 'text-gray-400 dark:text-gray-500'
+    disabled: 'text-gray-400 dark:text-gray-500 grayscale contrast-50'
   };
 </script>
 

--- a/src/lib/forms/Label.svelte
+++ b/src/lib/forms/Label.svelte
@@ -11,7 +11,7 @@
     gray: 'text-gray-900 dark:text-gray-300',
     green: 'text-green-700 dark:text-green-500',
     red: 'text-red-700 dark:text-red-500',
-    disabled: 'text-gray-400 dark:text-gray-500'
+    disabled: 'text-gray-400 dark:text-gray-500 grayscale contrast-50'
   };
 
   // function checkDisabled(node: HTMLLabelElement) {


### PR DESCRIPTION
Before:
![checkbox1](https://github.com/user-attachments/assets/a6ea0301-8c33-4899-8e59-c06a2752bcd0)

After:
![checkbox2](https://github.com/user-attachments/assets/d68547f3-85f8-49a5-9a9c-7da2e52c6414)

This PR makes it easier to distinguish between the active and the disabled state. When only the text has a different color but the checkbox still has the same users may think that a disabled checkbox can be toggled, especially if they don't have another checkbox to compare. When changing the color of both we ensure that users correctly interpret the state.

Furthermore, if you don't use a label it was not possible to see if a checkbox is disabled at all. With this change it is possible to detect the change.

Solves #1446.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of disabled elements in forms with updated styles for better contrast and clarity.
- **Bug Fixes**
	- Improved styling for disabled labels to ensure consistent appearance across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->