### PR TITLE
docs: modal dispatches open event instead of show

### DIFF
--- a/src/routes/docs/components/modal.md
+++ b/src/routes/docs/components/modal.md
@@ -28,7 +28,7 @@ Get started with multiple sizes, colors, and styles built with the utility class
 
 ## Default modal
 
-Modal visibility (open/close) is controlled by the `open` property. You can bind it to a variable that other element (usually button) will toggle. You can also use the `open=true` attribute to show open the modal by default. Opening and closing the modal will trigger the `show` and `close` events.
+Modal visibility (open/close) is controlled by the `open` property. You can bind it to a variable that other element (usually button) will toggle. You can also use the `open=true` attribute to show open the modal by default. Opening and closing the modal will trigger the `open` and `close` events.
 
 <p class="p-2"/>
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description

Just edited the correct event `open` instead of  `show` that is raised when the modal is opened.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated event names in the Svelte Modal component documentation for clarity (changed from `show` to `open`).
	- Ensured consistency in terminology throughout the documentation without altering examples or setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->