### PR TITLE
fix: add missing fields to $$Props in FloatingLableInput

### DIFF
--- a/src/lib/forms/FloatingLabelInput.svelte
+++ b/src/lib/forms/FloatingLabelInput.svelte
@@ -11,6 +11,9 @@
     size?: 'small' | 'default';
     color?: 'base' | 'green' | 'red';
     value?: any;
+    classDiv?: string;
+    classInput?: string;
+    classLabel?: string;
   }
 
   export let id: $$Props['id'] = generateId();
@@ -19,6 +22,9 @@
   export let size: NonNullable<$$Props['size']> = 'default';
   export let color: NonNullable<$$Props['color']> = 'base';
   export let value: $$Props['value'] = undefined;
+  export let classDiv: $$Props['classDiv'] = '';
+  export let classInput: $$Props['classInput'] = '';
+  export let classLabel: $$Props['classLabel'] = '';
 
   const divClasses = {
     filled: 'relative',
@@ -81,10 +87,10 @@
   };
 </script>
 
-<div class={twMerge(divClasses[style], $$props.classDiv)}>
-  <input {id} {...$$restProps} bind:value on:blur on:change on:click on:focus on:input on:keydown on:keypress on:keyup on:mouseenter on:mouseleave on:mouseover on:paste {...{ type }} placeholder=" " class={twMerge(inputClasses[style], inputColorClasses[color], inputSizes[style][size], $$props.classInput)} />
+<div class={twMerge(divClasses[style], classDiv)}>
+  <input {id} {...$$restProps} bind:value on:blur on:change on:click on:focus on:input on:keydown on:keypress on:keyup on:mouseenter on:mouseleave on:mouseover on:paste {...{ type }} placeholder=" " class={twMerge(inputClasses[style], inputColorClasses[color], inputSizes[style][size], classInput)} />
 
-  <label for={id} class={twMerge(labelClasses[style], labelColorClasses[color], labelSizes[style][size], $$props.classLabel)}>
+  <label for={id} class={twMerge(labelClasses[style], labelColorClasses[color], labelSizes[style][size], classLabel)}>
     <slot />
   </label>
 </div>
@@ -99,4 +105,7 @@
 @prop export let size: NonNullable<$$Props['size']> = 'default';
 @prop export let color: NonNullable<$$Props['color']> = 'base';
 @prop export let value: $$Props['value'] = undefined;
+@prop export let classDiv: $$Props['classDiv'] = '';
+@prop export let classInput: $$Props['classInput'] = '';
+@prop export let classLabel: $$Props['classLabel'] = '';
 -->

--- a/src/routes/component-data/FloatingLabelInput.json
+++ b/src/routes/component-data/FloatingLabelInput.json
@@ -1,13 +1,65 @@
 {
   "name": "FloatingLabelInput",
   "slots": [],
-  "events": ["blur", "change", "click", "focus", "input", "keydown", "keypress", "keyup", "mouseenter", "mouseleave", "mouseover", "paste"],
+  "events": [
+    "blur",
+    "change",
+    "click",
+    "focus",
+    "input",
+    "keydown",
+    "keypress",
+    "keyup",
+    "mouseenter",
+    "mouseleave",
+    "mouseover",
+    "paste"
+  ],
   "props": [
-    ["id?", "string", "generateId()"],
-    ["style?", "'filled' | 'outlined' | 'standard'", ""],
-    ["type?", "InputType", ""],
-    ["size?", "'small' | 'default'", ""],
-    ["color?", "'base' | 'green' | 'red'", ""],
-    ["value?", "any", "undefined"]
+    [
+      "id?",
+      "string",
+      "generateId()"
+    ],
+    [
+      "style?",
+      "'filled' | 'outlined' | 'standard'",
+      ""
+    ],
+    [
+      "type?",
+      "InputType",
+      ""
+    ],
+    [
+      "size?",
+      "'small' | 'default'",
+      ""
+    ],
+    [
+      "color?",
+      "'base' | 'green' | 'red'",
+      ""
+    ],
+    [
+      "value?",
+      "any",
+      "undefined"
+    ],
+    [
+      "classDiv?",
+      "string",
+      "''"
+    ],
+    [
+      "classInput?",
+      "string",
+      "''"
+    ],
+    [
+      "classLabel?",
+      "string",
+      "''"
+    ]
   ]
 }


### PR DESCRIPTION
## 📑 Description

The $$Props in multiple components are missing some fields that are used by the component.

If a component uses a prop by the $$prop syntax it will work when rendering but it will produce typescript errors.

This issue exists for multiple components, not just this one.

## ✅ Checks

- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed (Idk, i barely got the tests to run because of missing env-variables and timeouts)
- [x ] My pull request is based on the latest commit (not the npm version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `FloatingLabelInput` component with new optional properties for custom class names (`classDiv`, `classInput`, `classLabel`), allowing for improved styling flexibility.
- **Documentation**
	- Updated JSON configuration for the `FloatingLabelInput` component for better readability and included new properties in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->