### PR TITLE
feat: Add reactivity to toast wrapper

### DIFF
--- a/src/lib/toast/Toast.svelte
+++ b/src/lib/toast/Toast.svelte
@@ -42,7 +42,8 @@
     none: ''
   };
 
-  let finalDivClass: string = twMerge(
+  let finalDivClass: string;
+  $: finalDivClass = twMerge(
     'flex',
     align ? 'items-center' : 'items-start',
     divClass,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #<!-- Issue # here -->

## 📑 Description

<!-- Add a brief description of the PR -->

For my use case, the Toast component dark theme is very similar to my background. I wanted to add some styles to the border to match the icon class, however it was not reactive.

This PR adds reactivity to the wrapping div classes.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
![image](https://github.com/user-attachments/assets/0af28ef9-82d1-4afa-aea9-46524313abd3)

