### PR TITLE
fix: DatePicker light mode current month coloring

### DIFF
--- a/src/lib/datepicker/Datepicker.svelte
+++ b/src/lib/datepicker/Datepicker.svelte
@@ -280,7 +280,7 @@
           <Button on:click={() => changeMonth(-1)} {color} size="sm" aria-label="Previous month">
             <svg class="w-3 h-3 rtl:rotate-180 text-white dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5H1m0 0 4 4M1 5l4-4"></path></svg>
           </Button>
-          <h3 class="text-lg font-semibold dark:text-white" aria-live="polite">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white" aria-live="polite">
             {currentMonth.toLocaleString(locale, { month: 'long', year: 'numeric' })}
           </h3>
           <Button on:click={() => changeMonth(1)} {color} size="sm" aria-label="Next month">


### PR DESCRIPTION
## 📑 Description

When browsing the documentation for the DatePicker I noticed that when in light-mode the current month text display was invisible, upon further inspection I found it was actually just white matching with the background. When I looked at the component source I found that that specific text of the component only had a `dark` flag for the text-color which was causing this issue.

To remedy this I simply added a `text-gray-900` default text coloring to the current month text which seems to have fixed this issue. The component now successfully renders the text coloring on both light and dark mode.

Before:
<img width="441" alt="Screenshot 2025-04-04 at 12 10 29 PM" src="https://github.com/user-attachments/assets/7d0e4039-366b-4e4f-91f7-9e42d7db6f39" />

After:
<img width="433" alt="Screenshot 2025-04-04 at 12 10 46 PM" src="https://github.com/user-attachments/assets/4d208101-75ac-4a25-a2ac-170c0c431a32" />

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the readability of the date picker header by updating the light theme text color to gray while keeping the dark theme text white.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->