### PR TITLE
fix: modal scrolling on mobile/small screen-width

### DIFF
--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -138,7 +138,7 @@
   <!-- dialog -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <div on:keydown={handleKeys} on:wheel|preventDefault|nonpassive use:prepareFocus use:focusTrap on:click={onAutoClose} on:mousedown={onOutsideClose} class={dialogCls} tabindex="-1" aria-modal="true" role="dialog">
-    <div class="flex relative {sizes[size]} w-full max-h-full">
+    <div class="flex relative {sizes[size]} w-full max-h-screen">
       <!-- Modal content -->
       <Frame rounded shadow {...$$restProps} class={frameCls} {color}>
         <!-- Modal header -->


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1552 , #1264

## 📑 Description

It seems to occur if the screen hits <768px width. The scrollbar also vanishes at that point.
With a recent version of chromium the issue is reproducible when viewing the [docs example](https://flowbite-svelte.com/docs/components/modal#Scrolling_behaviour) .

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

I'm not 100% sure that this has no unexpected side-effects.

I've tested it on a current project of mine and the patched version seems to behave nicely on large and small screens - with less and more content.

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto1264-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the modal dialog display so it now utilizes the full height of the viewport rather than being constrained by its container, providing a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->