### PR TITLE
fix locale and firstday of the week

### DIFF
--- a/src/lib/datepicker/Datepicker.svelte
+++ b/src/lib/datepicker/Datepicker.svelte
@@ -57,8 +57,8 @@
     return daysArray;
   }
 
-  const getWeekdayNames = (locale = "en-US"): string[] => {
-    return Array.from({ length: 7 }, (_, i) => new Date(1970, 0, 4 + i).toLocaleDateString(locale, { weekday: "short" }));
+  const getWeekdayNames = (): string[] => {
+    return Array.from({ length: 7 }, (_, i) => new Date(1970, 0, 5 + i + firstDayOfWeek).toLocaleDateString(locale, { weekday: "short" }));
   };
   let weekdays = getWeekdayNames();
 


### PR DESCRIPTION
Simple fix for adding locale to the weekdays and fixing that firstdayoftheweek is used when getting weekdays.
## Status

- [] Not Completed
- [ X] Completed

## ✅ Checks

- [ x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [ x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Weekday names in the datepicker now correctly start from the configured first day of the week, improving localization and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->