### PR TITLE
Add onclick to <a> in NavLi

### DIFF
--- a/src/lib/navbar/NavLi.svelte
+++ b/src/lib/navbar/NavLi.svelte
@@ -25,7 +25,7 @@
       {@render children?.()}
     </button>
   {:else}
-    <a {...restProps} class={liClass}>
+    <a {...restProps} class={liClass} {onclick}>
       {@render children?.()}
     </a>
   {/if}


### PR DESCRIPTION
## 📑 Description

I am redirecting to some page without any reload of the page. I need to close the menu when I do that. Unfortunately, the `onclick` parameter is not giving to <a> and does not work in the current release.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured consistent click event handling for navigation items, whether displayed as a link or a button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->