### PR TITLE
fix: #1566 - carousel quick restart

### DIFF
--- a/src/lib/carousel/Carousel.svelte
+++ b/src/lib/carousel/Carousel.svelte
@@ -18,6 +18,7 @@
   });
 
   let forward = $state(true);
+  let initialized = false;
 
   subscribe((_state) => {
     index = _state.index;
@@ -27,6 +28,7 @@
 
   onMount(() => {
     onchange?.(images[index]);
+    initialized = true;
   });
 
   const nextSlide = () => {
@@ -49,20 +51,17 @@
     });
   };
 
-  const loop = (node: HTMLElement, duration: number) => {
+  const loop = (node: HTMLElement) => {
     // loop timer
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     let intervalId: any;
 
-    if (duration > 0) intervalId = setInterval(nextSlide, duration);
+    if (duration > 0) {
+      intervalId = setInterval(nextSlide, duration);
+      if (initialized) forward ? nextSlide() : prevSlide();
+    }
 
-    return {
-      update: (duration: number) => {
-        clearInterval(intervalId);
-        if (duration > 0) intervalId = setInterval(nextSlide, duration);
-      },
-      destroy: () => clearInterval(intervalId)
-    };
+    return () => clearInterval(intervalId);
   };
 
   type ActiveDragGesture = {
@@ -167,7 +166,7 @@
 <!-- The move listeners go here, so things keep working if the touch strays out of the element. -->
 <svelte:document onmousemove={onDragMove} onmouseup={onDragStop} ontouchmove={onDragMove} ontouchend={onDragStop} />
 <div bind:this={carouselDiv} class={cn("relative", divClass)} onmousedown={onDragStart} ontouchstart={onDragStart} onmousemove={onDragMove} onmouseup={onDragStop} ontouchmove={onDragMove} ontouchend={onDragStop} role="button" aria-label={ariaLabel} tabindex="0">
-  <div {...restProps} class={cn(carousel(), activeDragGesture === undefined ? "transition-transform" : "", className)} use:loop={duration}>
+  <div {...restProps} class={cn(carousel(), activeDragGesture === undefined ? "transition-transform" : "", className)} {@attach loop}>
     {#if slide}
       {@render slide({ index, Slide })}
     {:else}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1566 

## 📑 Description

When you change duration from 0 to non-zero the transitions starts instantly.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the carousel’s automatic slide looping behavior for more immediate slide advancement when looping is active.
  - Simplified how the carousel manages timing and lifecycle of automatic slide transitions.
- **Style**
  - Updated the way looping is applied to the carousel for a cleaner and more maintainable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->