### PR TITLE
fix: ButtonToggleGroup initial value

### DIFF
--- a/src/lib/forms/button-toggle/ButtonToggleGroup.svelte
+++ b/src/lib/forms/button-toggle/ButtonToggleGroup.svelte
@@ -2,12 +2,24 @@
   import { setContext } from "svelte";
   import { type ButtonToggleGroupProps, buttonToggleGroup, cn } from "$lib";
 
-  let { multiSelect = false, name = "toggle-group", value = multiSelect ? [] : null, color, size = "md", roundedSize = "md", onSelect = (val: any) => {}, children, ctxIconClass, ctxBtnClass, class: className, ...restProps }: ButtonToggleGroupProps = $props();
+  let { multiSelect = false, name = "toggle-group", value = null, color, size = "md", roundedSize = "md", onSelect = (val: any) => {}, children, ctxIconClass, ctxBtnClass, class: className, ...restProps }: ButtonToggleGroupProps = $props();
 
   const base = $derived(buttonToggleGroup({ roundedSize }));
   type SelectedValue = string | null | string[];
 
-  let selectedValues = $state<SelectedValue>(multiSelect ? [] : null);
+  if (multiSelect) {
+    if (value === null) {
+      value = [];
+    } else if (typeof value === "string") {
+      value = [value];
+    }
+  } else {
+    if (Array.isArray(value)) {
+      value = value[0] || null;
+    }
+  }
+
+  let selectedValues = $state<SelectedValue>(value);
 
   interface ButtonToggleContext {
     toggleSelected: (toggleValue: string) => void;


### PR DESCRIPTION
## Set the initial value passed to a `ButtonToggleGroup`  value prop.

The value passed in was being ignored is the component.

## Status

- [] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how selected values are handled in the button toggle group, ensuring correct behavior for both single and multi-select modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->