### PR TITLE
builders: fix for radio width

### DIFF
--- a/src/routes/builder/alert/+page.svelte
+++ b/src/routes/builder/alert/+page.svelte
@@ -153,7 +153,7 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="alert_reactive" bind:group={color} color={colorOption as AlertProps["color"]} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="alert_reactive" bind:group={color} color={colorOption as AlertProps["color"]} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">

--- a/src/routes/builder/avatar/+page.svelte
+++ b/src/routes/builder/avatar/+page.svelte
@@ -112,7 +112,7 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-12" name="spinnersize" bind:group={avatarSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="spinnersize" bind:group={avatarSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/badge/+page.svelte
+++ b/src/routes/builder/badge/+page.svelte
@@ -158,9 +158,9 @@
     <Button disabled={badgeStatus2 ? true : false} onclick={changeStatus}>Open badge</Button>
   </div>
   <div class="flex flex-wrap space-x-2">
-    <Label class="mb-4 w-full font-bold">Color</Label>
+    <Label class="mb-4 w-full font-bold">Color 1</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="color" bind:group={color} color={colorOption as BadgeProps["color"]} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="color" bind:group={color} color={colorOption as BadgeProps["color"]} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">

--- a/src/routes/builder/blockquote/+page.svelte
+++ b/src/routes/builder/blockquote/+page.svelte
@@ -90,13 +90,13 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-16" name="block_size" bind:group={selectedSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="block_size" bind:group={selectedSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Alignment</Label>
     {#each alignments as alignment}
-      <Radio class="my-1 w-16" name="block_alignment" bind:group={selectedAlignment} value={alignment}>{alignment}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="block_alignment" bind:group={selectedAlignment} value={alignment}>{alignment}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/button-group/+page.svelte
+++ b/src/routes/builder/button-group/+page.svelte
@@ -94,13 +94,13 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as sizeOption}
-      <Radio class="my-1 w-24" name="size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/button/+page.svelte
+++ b/src/routes/builder/button/+page.svelte
@@ -147,13 +147,13 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each btnColors as colorOption}
-      <Radio class="my-1 w-24" name="btn_color" bind:group={btnColor as ButtonProps["color"]} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="btn_color" bind:group={btnColor as ButtonProps["color"]} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each btnSizes as sizeOption}
-      <Radio class="my-1 w-24" name="btn_size" bind:group={btnSize as ButtonProps["size"]} value={sizeOption}>{sizeOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="btn_size" bind:group={btnSize as ButtonProps["size"]} value={sizeOption}>{sizeOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">
@@ -178,13 +178,13 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each gradientColors as colorOption}
-      <Radio class="my-1 w-32" name="gradient_color" bind:group={gradientColor} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-32" }} name="gradient_color" bind:group={gradientColor} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each gradientSizes as sizeOption}
-      <Radio class="my-1 w-24" name="gradient_size" bind:group={gradientSize as GradientButtonProps["size"]} value={sizeOption}>{sizeOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="gradient_size" bind:group={gradientSize as GradientButtonProps["size"]} value={sizeOption}>{sizeOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/card/+page.svelte
+++ b/src/routes/builder/card/+page.svelte
@@ -98,19 +98,19 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-16" name="interactive_card_size" bind:group={cardSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="interactive_card_size" bind:group={cardSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="alert_reactive" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="alert_reactive" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Shadow</Label>
     {#each shadows as shadow}
-      <Radio class="my-1 w-16" name="interactive_card_shadow" bind:group={cardShadow} value={shadow}>{shadow}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="interactive_card_shadow" bind:group={cardShadow} value={shadow}>{shadow}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/checkbox/+page.svelte
+++ b/src/routes/builder/checkbox/+page.svelte
@@ -79,7 +79,7 @@ ${helperState ? `<Helper class="ps-6">Helper text</Helper>` : ""}`;
   <div class="mt-4 mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="checkbox_color" bind:group={checkboxColor} color={colorOption as RadioColorType} onchange={() => (checkedState = true)} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="checkbox_color" bind:group={checkboxColor} color={colorOption as RadioColorType} onchange={() => (checkedState = true)} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/device-mockup/+page.svelte
+++ b/src/routes/builder/device-mockup/+page.svelte
@@ -147,7 +147,7 @@
   <div class="mb-8 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Device</Label>
     {#each deviceNames as device}
-      <Radio class="my-1 w-24" name="alert_reactive" bind:group={selectedDevice} value={device}>{device}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="alert_reactive" bind:group={selectedDevice} value={device}>{device}</Radio>
     {/each}
   </div>
   <DeviceMockup device={currentDevice.device as DeviceVariantType}>

--- a/src/routes/builder/dropdown/+page.svelte
+++ b/src/routes/builder/dropdown/+page.svelte
@@ -174,7 +174,7 @@
   <div class="flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Transition</Label>
     {#each transitions as transition}
-      <Radio class="my-1 w-24" name="dropdown_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="dropdown_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
     {/each}
   </div>
   {#snippet codeblock()}

--- a/src/routes/builder/file-input/+page.svelte
+++ b/src/routes/builder/file-input/+page.svelte
@@ -75,7 +75,7 @@ ${fileNames ? `{#each files as file}<p>{file.name}</p>{/each}` : ""}`;
   <div class="mt-4 mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as sizeOption}
-      <Radio class="my-1 w-16" name="file_input_size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="file_input_size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/floating-label/+page.svelte
+++ b/src/routes/builder/floating-label/+page.svelte
@@ -78,20 +78,20 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Style</Label>
     {#each inputStyles as option}
-      <Radio class="my-1 w-24" name="style1" bind:group={inputStyle} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="style1" bind:group={inputStyle} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="floating_color" bind:group={floatingColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="floating_color" bind:group={floatingColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Button class="mb-4 w-48" color="secondary" onclick={changeHelperSlot}>{helperSlot ? "Remove helper slot" : "Add helper slot"}</Button>
     <Label class="mb-4 w-full font-bold">Helper Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24 {helperSlot ? '' : 'cursor-not-allowed opacity-30'}" disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1 {helperSlot ? '' : 'cursor-not-allowed opacity-30'}" classes={{ label: "w-24" }} disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">

--- a/src/routes/builder/heading/+page.svelte
+++ b/src/routes/builder/heading/+page.svelte
@@ -69,7 +69,7 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Rounded</Label>
     {#each tags as tag}
-      <Radio class="my-1 w-12" name="tag" bind:group={headingTag} value={tag}>{tag}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="tag" bind:group={headingTag} value={tag}>{tag}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/hr/+page.svelte
+++ b/src/routes/builder/hr/+page.svelte
@@ -80,7 +80,7 @@
   <div class="flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each types as type}
-      <Radio class="my-1 w-20" name="hr_style" bind:group={selectedStyle} value={type}>{type}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="hr_style" bind:group={selectedStyle} value={type}>{type}</Radio>
     {/each}
   </div>
   {#snippet codeblock()}

--- a/src/routes/builder/image/+page.svelte
+++ b/src/routes/builder/image/+page.svelte
@@ -87,14 +87,14 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as option}
-      <Radio class="my-1 w-16" name="img_size" bind:group={imgSize} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="img_size" bind:group={imgSize} value={option}>{option}</Radio>
     {/each}
   </div>
 
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Effect</Label>
     {#each effects as effect}
-      <Radio class="my-1 w-24" name="img_effect" bind:group={imgEffect} value={effect}>{effect}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="img_effect" bind:group={imgEffect} value={effect}>{effect}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/indicators/+page.svelte
+++ b/src/routes/builder/indicators/+page.svelte
@@ -78,13 +78,13 @@
     <div class="flex flex-wrap space-x-4">
       <Label class="mb-4 w-full font-bold">Size</Label>
       {#each sizes as sizeOption}
-        <Radio class="my-1 w-24" name="size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
+        <Radio class="my-1" classes={{ label: "w-24" }} name="size" bind:group={size} value={sizeOption}>{sizeOption}</Radio>
       {/each}
     </div>
     <div class="flex flex-wrap space-x-4">
       <Label class="mb-4 w-full font-bold">Placement</Label>
       {#each placements as positionOption}
-        <Radio class="my-1 w-32" name="placement" bind:group={placement} value={positionOption}>{positionOption}</Radio>
+        <Radio class="my-1" classes={{ label: "w-32" }} name="placement" bind:group={placement} value={positionOption}>{positionOption}</Radio>
       {/each}
     </div>
     <Button onclick={changeBorder}>{border ? "Remove border" : "Add border"}</Button>

--- a/src/routes/builder/input-field/+page.svelte
+++ b/src/routes/builder/input-field/+page.svelte
@@ -92,20 +92,20 @@ ${closeBtnStatus ? `</Input>` : ""}${helperSlot ? `<Helper class="ps-6" color="$
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-20" name="input_color" bind:group={inputColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="input_color" bind:group={inputColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as option}
-      <Radio class="my-1 w-20" name="input_size" bind:group={inputSize} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="input_size" bind:group={inputSize} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Button class="mb-4 w-40" color="secondary" onclick={changeHelperSlot}>{helperSlot ? "Remove helper" : "Add helper"}</Button>
     <Label class="mb-4 w-full font-bold">Helper Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-20 {helperSlot ? '' : 'cursor-not-allowed opacity-30'}" disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1 {helperSlot ? '' : 'cursor-not-allowed opacity-30'}" classes={{ label: "w-20" }} disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/label/+page.svelte
+++ b/src/routes/builder/label/+page.svelte
@@ -48,7 +48,7 @@
   <div class="flex flex-wrap space-x-2">
     <Label class="m-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="default_alert_color" bind:group={labelColor} color={colorOption as ColorName} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="default_alert_color" bind:group={labelColor} color={colorOption as ColorName} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   {#snippet codeblock()}

--- a/src/routes/builder/link/+page.svelte
+++ b/src/routes/builder/link/+page.svelte
@@ -87,7 +87,7 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="anchor_color" bind:group={anchorColor} color={colorOption as AnchorColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="anchor_color" bind:group={anchorColor} color={colorOption as AnchorColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/list/+page.svelte
+++ b/src/routes/builder/list/+page.svelte
@@ -108,13 +108,13 @@
   <div class="mt-4 mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Tag</Label>
     {#each tags as tag}
-      <Radio class="my-1 w-20" name="list_tag" bind:group={listTag} value={tag}>{tag}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="list_tag" bind:group={listTag} value={tag}>{tag}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Position</Label>
     {#each positions as position}
-      <Radio class="my-1 w-20" name="list_position" bind:group={listPosition} value={position}>{position}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="list_position" bind:group={listPosition} value={position}>{position}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/modal/+page.svelte
+++ b/src/routes/builder/modal/+page.svelte
@@ -116,19 +116,19 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-12" name="modal-size" bind:group={modalSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="modal-size" bind:group={modalSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Position</Label>
     {#each placements as position}
-      <Radio class="my-1 w-32" name="modal-position" bind:group={placement} value={position}>{position}</Radio>
+      <Radio class="my-1" classes={{ label: "w-32" }} name="modal-position" bind:group={placement} value={position}>{position}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Transition</Label>
     {#each transitions as transition}
-      <Radio class="my-1 w-16" name="transition_interactive" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="transition_interactive" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
     {/each}
   </div>
   {#snippet codeblock()}

--- a/src/routes/builder/paragraph/+page.svelte
+++ b/src/routes/builder/paragraph/+page.svelte
@@ -84,37 +84,37 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-12" name="p_size" bind:group={pSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="p_size" bind:group={pSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Weight</Label>
     {#each weights as weight}
-      <Radio class="my-1 w-20" name="p_weight" bind:group={pWeight} value={weight}>{weight}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="p_weight" bind:group={pWeight} value={weight}>{weight}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Space(Tracking)</Label>
     {#each spaces as space}
-      <Radio class="my-1 w-20" name="p_space" bind:group={pSpace} value={space}>{space}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="p_space" bind:group={pSpace} value={space}>{space}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Height(Leading)</Label>
     {#each heights as height}
-      <Radio class="my-1 w-16" name="p_height" bind:group={pHeight} value={height}>{height}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="p_height" bind:group={pHeight} value={height}>{height}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Alignment</Label>
     {#each alignments as align}
-      <Radio class="my-1 w-20" name="p_align" bind:group={pAlign} onchange={() => (pJustify = false)} value={align}>{align}</Radio>
+      <Radio class="my-1" classes={{ label: "w-20" }} name="p_align" bind:group={pAlign} onchange={() => (pJustify = false)} value={align}>{align}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Whitespace</Label>
     {#each whitespaces as whitespace}
-      <Radio class="my-1 w-16" name="p_whitespace" bind:group={pWhitespace} value={whitespace}>{whitespace}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="p_whitespace" bind:group={pWhitespace} value={whitespace}>{whitespace}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/popover/+page.svelte
+++ b/src/routes/builder/popover/+page.svelte
@@ -119,19 +119,19 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="alert_reactive" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="alert_reactive" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Position</Label>
     {#each placements as option}
-      <Radio class="my-1 w-28" name="interactive_toast_position" bind:group={placement} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-28" }} name="interactive_toast_position" bind:group={placement} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Transition</Label>
     {#each transitions as transition}
-      <Radio class="my-1 w-16" name="interactive_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="interactive_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/progress/+page.svelte
+++ b/src/routes/builder/progress/+page.svelte
@@ -111,13 +111,13 @@
   <div class="mb-8 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each progressSizes as size}
-      <Radio class="my-1 w-24" name="progress_size" bind:group={progressSize.size} value={size.size} onchange={() => updateProgressSize(size.size)}>{size.size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="progress_size" bind:group={progressSize.size} value={size.size} onchange={() => updateProgressSize(size.size)}>{size.size}</Radio>
     {/each}
   </div>
   <div class="mb-8 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as color}
-      <Radio class="my-1 w-24" name="interactive_progress_color" bind:group={progressColor} color={color as RadioColorType} value={color}>{color}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="interactive_progress_color" bind:group={progressColor} color={color as RadioColorType} value={color}>{color}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/radio/+page.svelte
+++ b/src/routes/builder/radio/+page.svelte
@@ -104,14 +104,14 @@ ${helperSlot ? `<Helper class="ps-6" color="${helperColor}">Helper text</Helper>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="radio_color" bind:group={radioColor} onchange={() => handleOnchange(colorOption)} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="radio_color" bind:group={radioColor} onchange={() => handleOnchange(colorOption)} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Button class="mb-4 w-40" color="secondary" onclick={changeHelperSlot}>{helperSlot ? "Remove helper" : "Add helper"}</Button>
     <Label class="mb-4 w-full font-bold">Helper Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24 {helperSlot ? '' : 'cursor-not-allowed opacity-30'}" disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1{helperSlot ? '' : 'cursor-not-allowed opacity-30'}" classes={{ label: "w-24" }} disabled={helperSlot ? false : true} name="helper_color" bind:group={helperColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/range/+page.svelte
+++ b/src/routes/builder/range/+page.svelte
@@ -95,7 +95,7 @@ ${
   <div class="mt-12 mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="default_alert_color" bind:group={rangeColor} color={colorOption as RangeColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="default_alert_color" bind:group={rangeColor} color={colorOption as RangeColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/select/+page.svelte
+++ b/src/routes/builder/select/+page.svelte
@@ -103,7 +103,7 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as option}
-      <Radio class="my-1 w-24" name="input_size" bind:group={selectSize} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="input_size" bind:group={selectSize} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/skeleton/+page.svelte
+++ b/src/routes/builder/skeleton/+page.svelte
@@ -92,7 +92,7 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size(width)</Label>
     {#each skeletonSizes as size}
-      <Radio class="my-1 w-12" name="skeletonsize" bind:group={skeletonSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="skeletonsize" bind:group={skeletonSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (skeletonClass === "" ? (skeletonClass = "ml-4") : (skeletonClass = ""))}>{skeletonClass ? "Remove class" : "Add class"}</Button>
@@ -109,13 +109,13 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each imageSizes as size}
-      <Radio class="my-1 w-12" name="imageSize" bind:group={imagePlaceholderSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="imageSize" bind:group={imagePlaceholderSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Rounded</Label>
     {#each imageRoundedSizes as size}
-      <Radio class="my-1 w-12" name="imageRoundedSize" bind:group={imagePlaceholderRounded} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="imageRoundedSize" bind:group={imagePlaceholderRounded} value={size}>{size}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (imagePlaceholderClass === "" ? (imagePlaceholderClass = "ml-4") : (imagePlaceholderClass = ""))}>{imagePlaceholderClass ? "Remove class" : "Add class"}</Button>
@@ -132,7 +132,7 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size(width)</Label>
     {#each videoSizes as size}
-      <Radio class="my-1 w-12" name="videoSize" bind:group={videoPlaceholderSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="videoSize" bind:group={videoPlaceholderSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (videoPlaceholderClass === "" ? (videoPlaceholderClass = "ml-4") : (videoPlaceholderClass = ""))}>{videoPlaceholderClass ? "Remove class" : "Add class"}</Button>
@@ -147,7 +147,7 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size(width)</Label>
     {#each textSizes as size}
-      <Radio class="my-1 w-12" name="textSize" bind:group={textPlaceholderSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="textSize" bind:group={textPlaceholderSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (textPlaceholderClass === "" ? (textPlaceholderClass = "ml-4") : (textPlaceholderClass = ""))}>{textPlaceholderClass ? "Remove class" : "Add class"}</Button>
@@ -162,7 +162,7 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size(width)</Label>
     {#each cardSizes as size}
-      <Radio class="my-1 w-12" name="cardSize" bind:group={cardPlaceholderSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="cardSize" bind:group={cardPlaceholderSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (cardPlaceholderClass === "" ? (cardPlaceholderClass = "ml-4") : (cardPlaceholderClass = ""))}>{cardPlaceholderClass ? "Remove class" : "Add class"}</Button>
@@ -188,19 +188,19 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each listSizes as size}
-      <Radio class="my-1 w-12" name="size" bind:group={listPlaceholderSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="size" bind:group={listPlaceholderSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Rounded</Label>
     {#each listRoundedSizes as size}
-      <Radio class="my-1 w-12" name="roundedSize" bind:group={listPlaceholderRounded} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="roundedSize" bind:group={listPlaceholderRounded} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Items:</Label>
     {#each listItemNumbers as itemNumber}
-      <Radio class="my-1 w-10" name="itemNumber" bind:group={listPlaceholderItemNumber} value={itemNumber}>{itemNumber}</Radio>
+      <Radio class="my-1" classes={{ label: "w-10" }} name="itemNumber" bind:group={listPlaceholderItemNumber} value={itemNumber}>{itemNumber}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={() => (listPlaceholderClass === "" ? (listPlaceholderClass = "ml-4") : (listPlaceholderClass = ""))}>{listPlaceholderClass ? "Remove class" : "Add class"}</Button>

--- a/src/routes/builder/span/+page.svelte
+++ b/src/routes/builder/span/+page.svelte
@@ -113,7 +113,8 @@
     <Label class="mb-4 w-full font-bold">Highlight</Label>
     {#each highlights as highlight}
       <Radio
-        class="my-1 w-20"
+        class="my-1"
+        classes={{ label: "w-20" }}
         name="span_highlight"
         bind:group={spanHighlight}
         onchange={() => {
@@ -130,14 +131,15 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Gradient</Label>
     {#each gradients as gradient}
-      <Radio class="my-1 w-40" name="span_gradient" bind:group={spanGradient} onchange={() => (spanHighlight = "none")} value={gradient}>{gradient}</Radio>
+      <Radio class="my-1" classes={{ label: "w-40" }} name="span_gradient" bind:group={spanGradient} onchange={() => (spanHighlight = "none")} value={gradient}>{gradient}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Decoration thickness</Label>
     {#each docrationThickness as thickness}
       <Radio
-        class="my-1 w-16"
+        class="my-1"
+        classes={{ label: "w-16" }}
         name="span_decoration_thickness"
         bind:group={spanDecorationThickness}
         onchange={() => {
@@ -154,7 +156,8 @@
     <Label class="mb-4 w-full font-bold">Decoration color</Label>
     {#each decorationColors as color}
       <Radio
-        class="my-1 w-24"
+        class="my-1"
+        classes={{ label: "w-24" }}
         name="p_decoration_color"
         bind:group={spanDecorationColor}
         onchange={() => {
@@ -172,7 +175,8 @@
     <Label class="mb-4 w-full font-bold">Decoration</Label>
     {#each decorations as decoration}
       <Radio
-        class="my-1 w-20"
+        class="my-1"
+        classes={{ label: "w-20" }}
         name="span_decoration"
         bind:group={spanDecoration}
         onchange={() => {

--- a/src/routes/builder/spinner/+page.svelte
+++ b/src/routes/builder/spinner/+page.svelte
@@ -76,19 +76,19 @@
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as color}
-      <Radio class="my-1 w-24" name="spinnercolor" bind:group={spinnerColor} color={color as RadioColorType} value={color}>{color}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="spinnercolor" bind:group={spinnerColor} color={color as RadioColorType} value={color}>{color}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="my-1 w-12" name="spinnersize" bind:group={spinnerSize} value={size}>{size}</Radio>
+      <Radio class="my-1" classes={{ label: "w-12" }} name="spinnersize" bind:group={spinnerSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Alignment</Label>
     {#each alignments as option}
-      <Radio class="my-1 w-16" name="alignment" bind:group={selectedAlignment} value={option.name}>{option.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="alignment" bind:group={selectedAlignment} value={option.name}>{option.name}</Radio>
     {/each}
   </div>
   <Button class="w-36" onclick={changeClass}>{spinnerClass ? "Remove class" : "Add class"}</Button>

--- a/src/routes/builder/tab/+page.svelte
+++ b/src/routes/builder/tab/+page.svelte
@@ -118,7 +118,7 @@
     <Label class="mb-4 w-full font-bold">Style</Label>
     {#each tabStyles as option}
       {#if option !== "full"}
-        <Radio class="my-1 w-24" name="table_color" bind:group={tabStyle} value={option}>{option}</Radio>
+        <Radio class="my-1" classes={{ label: "w-24" }} name="table_color" bind:group={tabStyle} value={option}>{option}</Radio>
       {/if}
     {/each}
   </div>

--- a/src/routes/builder/table/+page.svelte
+++ b/src/routes/builder/table/+page.svelte
@@ -77,7 +77,7 @@
   <div class="my-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="table_color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="table_color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex gap-4">

--- a/src/routes/builder/toast/+page.svelte
+++ b/src/routes/builder/toast/+page.svelte
@@ -105,19 +105,19 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="interactive_toast_color" bind:group={toastColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="interactive_toast_color" bind:group={toastColor} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Transition</Label>
     {#each transitions as transition}
-      <Radio class="my-1 w-16" name="interactive_toast_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-16" }} name="interactive_toast_transition" bind:group={selectedTransition} value={transition.name}>{transition.name}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Position</Label>
     {#each positions as option}
-      <Radio class="my-1 w-32" name="interactive_toast_position" bind:group={toastPosition} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-32" }} name="interactive_toast_position" bind:group={toastPosition} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap gap-2">

--- a/src/routes/builder/toggle/+page.svelte
+++ b/src/routes/builder/toggle/+page.svelte
@@ -90,13 +90,13 @@
   <div class="mb-4 flex flex-wrap">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="m-2 w-24" name="toggle_color" bind:group={toggleColor} color={colorOption as ToggleColor} value={colorOption}>{colorOption}</Radio>
+      <Radio class="m-2" classes={{ label: "w-24" }} name="toggle_color" bind:group={toggleColor} color={colorOption as ToggleColor} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-4">
     <Label class="mb-4 w-full font-bold">Size</Label>
     {#each sizes as size}
-      <Radio class="m-2 w-32" name="toggle_size" bind:group={toggleSize} value={size}>{size}</Radio>
+      <Radio class="m-2" classes={{ label: "w-32" }} name="toggle_size" bind:group={toggleSize} value={size}>{size}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">

--- a/src/routes/builder/tooltip/+page.svelte
+++ b/src/routes/builder/tooltip/+page.svelte
@@ -81,13 +81,13 @@
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Color</Label>
     {#each colors as colorOption}
-      <Radio class="my-1 w-24" name="color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="color" bind:group={color} color={colorOption as RadioColorType} value={colorOption}>{colorOption}</Radio>
     {/each}
   </div>
   <div class="mb-4 flex flex-wrap space-x-2">
     <Label class="mb-4 w-full font-bold">Position</Label>
     {#each placements as option}
-      <Radio class="my-1 w-20" name="interactive_toast_position" bind:group={placement} value={option}>{option}</Radio>
+      <Radio class="my-1" classes={{ label: "w-32" }} name="interactive_toast_position" bind:group={placement} value={option}>{option}</Radio>
     {/each}
   </div>
   <div class="mb-4">

--- a/src/routes/builder/video/+page.svelte
+++ b/src/routes/builder/video/+page.svelte
@@ -77,7 +77,7 @@
   <div class="mb-4 flex flex-wrap space-x-6">
     <Label class="mb-4 w-full font-bold">Style</Label>
     {#each videoClasses as option}
-      <Radio class="my-1 w-24" name="interactive_toast_color" bind:group={selectedClass} value={option.name}>{option.name}</Radio>
+      <Radio class="my-1" classes={{ label: "w-24" }} name="interactive_toast_color" bind:group={selectedClass} value={option.name}>{option.name}</Radio>
     {/each}
   </div>
   <div class="flex flex-wrap justify-center gap-2 md:justify-start">


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #<!-- Issue # here -->

## 📑 Description

`Radio`s in builders have width mess up.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] I have checked the page with https://validator.unl.edu/
- [ ] All the tests have passed
- [ ] My pull request is based on the latest commit (not the npm version).

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the styling approach for all builder UI Radio components by moving width-related classes from the root element to the label element. This change ensures more consistent and targeted width styling across color, size, and option selectors throughout the builder interface.
  * Minor label text adjustment in the badge builder ("Color" to "Color 1").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->