### PR TITLE
fix: speed-dial - layout for text inside

### DIFF
--- a/src/lib/speed-dial/SpeedDialButton.svelte
+++ b/src/lib/speed-dial/SpeedDialButton.svelte
@@ -22,15 +22,11 @@
 
   const theme = getTheme("speedDialButton");
 
-  let { base, span } = $derived(speedDialButton({ textOutside }));
+  let { base, span } = $derived(speedDialButton({ textOutside, noTooltip: tooltip === "none" }));
   let spanCls = $derived(tooltip === "none" ? span({ class: clsx(theme?.span, styling.span) }) : "sr-only");
 
   // Add flex-col when tooltip is shown
-  let buttonCls = $derived(
-    base({
-      class: clsx(theme?.base, className, tooltip !== "none" && "flex-col")
-    })
-  );
+  let buttonCls = $derived(base({ class: clsx(theme?.base, className) }));
 </script>
 
 <Button {pill} {color} {...restProps} class={buttonCls}>

--- a/src/lib/speed-dial/SpeedDialButton.svelte
+++ b/src/lib/speed-dial/SpeedDialButton.svelte
@@ -23,9 +23,8 @@
   const theme = getTheme("speedDialButton");
 
   let { base, span } = $derived(speedDialButton({ textOutside, noTooltip: tooltip === "none" }));
-  let spanCls = $derived(tooltip === "none" ? span({ class: clsx(theme?.span, styling.span) }) : "sr-only");
+  let spanCls = $derived(tooltip === "none" || textOutside ? span({ class: clsx(theme?.span, styling.span) }) : "sr-only");
 
-  // Add flex-col when tooltip is shown
   let buttonCls = $derived(base({ class: clsx(theme?.base, className) }));
 </script>
 

--- a/src/lib/speed-dial/theme.ts
+++ b/src/lib/speed-dial/theme.ts
@@ -28,7 +28,7 @@ export const speedDialButton = tv({
   variants: {
     noTooltip: {
       false: {},
-      true: {base: "flex flex-col"}
+      true: {}
     },
     textOutside: {
       true: {
@@ -37,5 +37,11 @@ export const speedDialButton = tv({
       }
     }
   },
+  compoundVariants:[
+    {noTooltip: true,
+      textOutside: false,
+      class: {base: "flex flex-col"}
+    }
+  ],
   defaultVariants: {}
 });

--- a/src/lib/speed-dial/theme.ts
+++ b/src/lib/speed-dial/theme.ts
@@ -23,9 +23,13 @@ export const speedDial = tv({
 export const speedDialButton = tv({
   slots: {
     base: "w-[52px] h-[52px] shadow-xs p-0",
-    span: "block mb-px text-xs font-medium"
+    span: "mb-px text-xs font-medium"
   },
   variants: {
+    noTooltip: {
+      false: {},
+      true: {base: "flex flex-col"}
+    },
     textOutside: {
       true: {
         base: "relative",


### PR DESCRIPTION


## 📑 Description

Layout for `SpeedDial` text inside was broken. Text was aside instead of being vertical.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [x] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Option to render Speed Dial buttons without tooltips for minimal UI.

- Style
  - Labels refined for cleaner spacing and visual consistency.
  - Buttons stack vertically when tooltips are disabled for clearer presentation.

- Refactor
  - Simplified button layout logic to ensure consistent base styling regardless of tooltip state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->