### PR TITLE
fix: drawer - remove blink before transition start

### DIFF
--- a/src/lib/drawer/Drawer.svelte
+++ b/src/lib/drawer/Drawer.svelte
@@ -73,11 +73,14 @@
 
     x = placement === "left" ? rect.left : placement === "right" ? rect.right - innerWidth : undefined;
     y = placement === "top" ? rect.top : placement === "bottom" ? rect.bottom - innerHeight : undefined;
-    // remove shift for transition end position
-    shifted = false;
 
-    // add offset if closed, remove it when open
-    if (offset) dlg.style[placement] = open ? "" : offset;
+    tick().then(() => {
+      // remove shift for transition end position
+      shifted = false;
+
+      // add offset if closed, remove it when open
+      if (offset) dlg.style[placement] = open ? "" : offset;
+    });
   }
 
   function onoutrostart(ev: CustomEvent & { currentTarget: HTMLDialogElement }) {


### PR DESCRIPTION

## 📑 Description

Delay the reposition of `Drawer` on transition start to avoid an ugly blink.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [x] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
