### PR TITLE
fix: use `esm-env` instead of `import.meta.env.MODE`

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "apexcharts": "^5.3.5",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "esm-env": "^1.2.2",
     "flowbite": "^3.1.2",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      esm-env:
+        specifier: ^1.2.2
+        version: 1.2.2
       flowbite:
         specifier: ^3.1.2
         version: 3.1.2(rollup@4.52.2)

--- a/src/lib/theme/themeUtils.ts
+++ b/src/lib/theme/themeUtils.ts
@@ -1,9 +1,7 @@
 import { type ThemeConfig } from "$lib";
 import type { ClassValue } from "clsx";
 import { getContext } from "svelte";
-// import { dev } from "$app/environment";
-// for svelte users not using sveltekit substitute the above line with the following line
-const dev = import.meta.env.MODE === "development";
+import { DEV } from "esm-env";
 
 export function getTheme<K extends keyof ThemeConfig>(componentKey: K) {
   const theme = getContext<ThemeConfig>("theme");
@@ -25,7 +23,7 @@ export type Classes<T extends { slots: Record<string, unknown> }> = {
  * @param replacements - Optional map of deprecated keys to their replacements (e.g., "divClass" → "div").
  */
 export function warnThemeDeprecation(component: string, names: Record<string, unknown>, replacements?: Record<string, unknown>): void {
-  if (!dev) return;
+  if (!DEV) return;
 
   const nonEmptyNames = Object.keys(names).filter((name) => names[name]);
   if (nonEmptyNames.length === 0) return;


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte.dev/issues/1410
Closes https://github.com/themesberg/flowbite-svelte/issues/1662
Closes https://github.com/sveltejs/svelte.dev/pull/1536

## 📑 Description

This PR swaps out the use of `import.meta.env.MODE` with `esm-env`. This makes the library work with environments that don't have `import.meta.env.MODE`. `esm-env` is also what SvelteKit uses for dev mode checks.

No test because I've no idea how to remove `import.meta.env` when importing the module in Vitest.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [ ] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [ ] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a runtime dependency to centralize environment detection.
  - Dev-mode warnings/diagnostics now use that external environment flag.
  - No user-facing UI or feature changes are expected; behavior for end users remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->