### PR TITLE
fix #1775

### DIFF
--- a/src/lib/forms/input-field/Input.svelte
+++ b/src/lib/forms/input-field/Input.svelte
@@ -225,7 +225,7 @@
         {@render left()}
       </div>
     {/if}
-    {@render inputContent()}
+    {@render inputContent(true)}
     {#if right}
       <div class={rightCls({ class: clsx(theme?.right, styling.right) })}>
         {@render right()}
@@ -243,14 +243,14 @@
     {/if}
   </div>
 {:else}
-  {@render inputContent()}
+  {@render inputContent(false)}
 {/if}
 
-{#snippet inputContent()}
+{#snippet inputContent(wrapped: boolean)}
   {#if children}
     {@render children({ ...restProps, class: inputCls() })}
   {:else}
-    <input {...restProps} bind:value bind:this={elementRef} oninput={handleInput} onfocus={handleFocus} onblur={handleBlur} onkeydown={handleKeydown} class={inputCls({ class: clsx(theme?.input, className) })} />
+    <input {...restProps} bind:value bind:this={elementRef} oninput={handleInput} onfocus={handleFocus} onblur={handleBlur} onkeydown={handleKeydown} class={[wrapped || base(), inputCls({ class: clsx(theme?.input, className) })]} />
     {#if value !== undefined && value !== "" && clearable}
       <CloseButton class={close({ class: clsx(theme?.close, styling.close) })} color={clearableColor} aria-label="Clear search value" svgClass={clsx(styling.svg)} />
     {/if}

--- a/src/lib/forms/input-field/theme.ts
+++ b/src/lib/forms/input-field/theme.ts
@@ -91,9 +91,10 @@ export const input = tv({
       }
     },
     grouped: {
-      false: { input: "rounded-lg" },
+      false: { base: "rounded-lg", input: "rounded-lg" },
       true: {
-        input: "first:rounded-s-lg last:rounded-e-lg not-first:-ms-px"
+        base: "first:rounded-s-lg last:rounded-e-lg not-first:-ms-px group",
+        input: "group-first:rounded-s-lg group-last:rounded-e-lg group-not-first:-ms-px"
       }
     }
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1775 

## 📑 Description

When `clearable` is set, `input` element gets wrapped and therefore `first:` and `last:` classes did not get work.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [ ] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for wrapped/unwrapped input states to ensure correct styling across different layouts.
- Style
  - Improved grouped input appearance with consistent rounded corners, borders, and spacing for first/last items.
  - Refined theming to separate container and input styles, delivering more predictable visual consistency in groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->