### PR TITLE
fix #1775 - h-full for wrapped input

### DIFF
--- a/src/lib/forms/input-field/theme.ts
+++ b/src/lib/forms/input-field/theme.ts
@@ -94,7 +94,7 @@ export const input = tv({
       false: { base: "rounded-lg", input: "rounded-lg" },
       true: {
         base: "first:rounded-s-lg last:rounded-e-lg not-first:-ms-px group",
-        input: "group-first:rounded-s-lg group-last:rounded-e-lg group-not-first:-ms-px"
+        input: "group-first:rounded-s-lg group-last:rounded-e-lg group-not-first:-ms-px h-full"
       }
     }
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #1775

## 📑 Description

Added `h-full` for `Input` if it sits in `ButtonGroup` to align heights.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [ ] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
