### PR TITLE
fix: #1792 MultiSelect: change (item.name) to (item.value) as the key

### DIFF
--- a/src/lib/forms/select/MultiSelect.svelte
+++ b/src/lib/forms/select/MultiSelect.svelte
@@ -209,7 +209,7 @@
   {/if}
   <span class={select({ class: clsx(theme?.select, classes?.span) })}>
     {#if selectItems.length}
-      {#each selectItems as item (item.name)}
+      {#each selectItems as item (item.value)}
         {#if children}
           {@render children({ item, clear: () => clearThisOption(item) })}
         {:else}
@@ -232,7 +232,7 @@
 
   {#if show}
     <div role="presentation" class={dropdown({ class: clsx(styling.dropdown) })}>
-      {#each items as item (item.name)}
+      {#each items as item (item.value)}
         <div
           onclick={(e) => selectOption(item, e)}
           role="presentation"

--- a/src/routes/docs-examples/forms/select/Customization.svelte
+++ b/src/routes/docs-examples/forms/select/Customization.svelte
@@ -13,7 +13,7 @@
 
 <MultiSelect items={countries} value={selected}>
   {#snippet children({ item, clear })}
-    <Badge color={item.color} dismissable params={{ duration: 100 }} onclose={clear}>
+    <Badge color={item.color} dismissable params={{ duration: 100 }} onclose={clear} class="mx-0.5">
       {item.name}
     </Badge>
   {/snippet}

--- a/src/routes/docs-examples/forms/select/Preselect.svelte
+++ b/src/routes/docs-examples/forms/select/Preselect.svelte
@@ -13,7 +13,7 @@
 
 <MultiSelect items={colorCountries} value={preselected}>
   {#snippet children({ item, clear })}
-    <Badge color={item.color} dismissable params={{ duration: 100 }} onclose={clear}>
+    <Badge color={item.color} dismissable params={{ duration: 100 }} onclose={clear} class="mx-0.5">
       {item.name}
     </Badge>
   {/snippet}


### PR DESCRIPTION
Closes #1792 

## 📑 Description

- The fix changes both #each blocks from using (item.name) to (item.value) as the key:

Line 212 (selected items badges): {#each selectItems as item (item.value)}
Line 233 (dropdown items): {#each items as item (item.value)}

This ensures Svelte can properly track each item even when they have the same display name, since the value property should always be unique in your items array.

- add `mx-0.5` to Badge in MultiSelect examples.

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation and `api-check` directory as required
- [x] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-select component's item tracking behavior during reordering operations

* **Style**
  * Added spacing refinements to badge elements in select form components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->