### PR TITLE
docs: correct "tiggering" typo

### DIFF
--- a/src/routes/docs/components/popover.md
+++ b/src/routes/docs/components/popover.md
@@ -123,7 +123,7 @@ You can also disable the popover arrow by setting `arrow` attribute to `false`.
 
 ## External reference
 
-If you need the popover to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the popover to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte example class="flex gap-4 flex-col justify-end items-center h-64" hideResponsiveButtons
 {#include External.svelte}

--- a/src/routes/docs/components/tooltip.md
+++ b/src/routes/docs/components/tooltip.md
@@ -29,7 +29,7 @@ For interactive elements that need to display additional content on click, use t
 
 ## Default tooltip example
 
-To get started with using tooltips all you need to do is to place `Tooltip` element directly after tiggering element (usually `Button`).
+To get started with using tooltips all you need to do is to place `Tooltip` element directly after triggering element (usually `Button`).
 In the following example you can see the tooltip that will be trigger by the adjacent element to be shown when hovered or focused.
 
 ```svelte example class="flex items-end h-32" hideResponsiveButtons
@@ -78,7 +78,7 @@ The positioning of the tooltip element relative to the triggering element (eg. b
 
 ## External reference
 
-If you need the tooltip to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the tooltip to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte example class="flex gap-4 flex-col justify-center items-center h-72" hideResponsiveButtons
 {#include External.svelte}

--- a/static/llm/components/popover.md
+++ b/static/llm/components/popover.md
@@ -363,7 +363,7 @@ You can also disable the popover arrow by setting `arrow` attribute to `false`.
 
 ## External reference
 
-If you need the popover to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the popover to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte
 <script lang="ts">

--- a/static/llm/components/tooltip.md
+++ b/static/llm/components/tooltip.md
@@ -15,7 +15,7 @@ For interactive elements that need to display additional content on click, use t
 
 ## Default tooltip example
 
-To get started with using tooltips all you need to do is to place `Tooltip` element directly after tiggering element (usually `Button`).
+To get started with using tooltips all you need to do is to place `Tooltip` element directly after triggering element (usually `Button`).
 In the following example you can see the tooltip that will be trigger by the adjacent element to be shown when hovered or focused.
 
 ```svelte
@@ -111,7 +111,7 @@ The positioning of the tooltip element relative to the triggering element (eg. b
 
 ## External reference
 
-If you need the tooltip to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the tooltip to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte
 <script lang="ts">

--- a/static/llm/context-full.txt
+++ b/static/llm/context-full.txt
@@ -11416,7 +11416,7 @@ You can also disable the popover arrow by setting `arrow` attribute to `false`.
 
 ## External reference
 
-If you need the popover to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the popover to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte
 <script lang="ts">
@@ -17430,7 +17430,7 @@ For interactive elements that need to display additional content on click, use t
 
 ## Default tooltip example
 
-To get started with using tooltips all you need to do is to place `Tooltip` element directly after tiggering element (usually `Button`).
+To get started with using tooltips all you need to do is to place `Tooltip` element directly after triggering element (usually `Button`).
 In the following example you can see the tooltip that will be trigger by the adjacent element to be shown when hovered or focused.
 
 ```svelte
@@ -17526,7 +17526,7 @@ The positioning of the tooltip element relative to the triggering element (eg. b
 
 ## External reference
 
-If you need the tooltip to be attached to the other element then the tiggering one you can pass a CSS query to `reference` prop.
+If you need the tooltip to be attached to the other element then the triggering one you can pass a CSS query to `reference` prop.
 
 ```svelte
 <script lang="ts">


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

Correct a typo in docs for `<Tooltip />`

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation and `api-check` directory as required
- [x] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [x] I have checked the page with https://validator.unl.edu/

<!--

Sync fork from GitHub dropdown and update your local branch.

```sh
git pull origin main
git checkout your-branch
git rebase main
npm run test
git push
```

Then create a PR from your GitHub repo.

Or if you are using the command line:

```sh
git checkout main
git fetch upstream // I'm assuming you set the upstream
git merge upstream/main
```

Then change to your branch:

```sh
git checkout my-new-feature
git merge main
```

If you may need to resolve merge conficts if your local branch had unique commits.

Now you are ready to submit your PR.

It’s a good idea to sync from time to
time, so you aren’t left too far behind the parent branch.

-->

## ℹ Additional Information

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typos in popover and tooltip component documentation
  * Enhanced clarifications and consistency across component property descriptions
  * Improved readability and semantic accuracy of component guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->