### PR TITLE
fix: #1797 correct date range swap when selecting earlier end date

### DIFF
--- a/src/lib/datepicker/Datepicker.svelte
+++ b/src/lib/datepicker/Datepicker.svelte
@@ -107,8 +107,9 @@
         rangeFrom = day;
         rangeTo = undefined;
       } else if (day < rangeFrom) {
+        const oldRangeFrom = rangeFrom;
         rangeFrom = day;
-        rangeTo = rangeFrom;
+        rangeTo = oldRangeFrom;
       } else {
         rangeTo = day;
       }


### PR DESCRIPTION
Closes #1797 

## 📑 Description

Store old rangeFrom value before overwriting to properly swap dates when user selects an earlier date as range end

## Status

- [ ] Not Completed
- [x] Completed

## ✅ Checks

<!-- Make sure your PR passes the tests and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation and `api-check` directory as required
- [x] All the tests and check have passed by running `pnpm check && pnpm test:e2e`
- [x] My pull request is based on the latest commit (not the npm version).
- [ ] I have checked the page with https://validator.unl.edu/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range selection behavior to correctly preserve the end date when selecting a start date earlier than the current range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->