### PR TITLE
Fix MultiSelect not working in label elements

### DIFF
--- a/src/lib/forms/select/MultiSelect.svelte
+++ b/src/lib/forms/select/MultiSelect.svelte
@@ -24,6 +24,7 @@
     class: className,
     classes,
     // Extract select-specific props
+    id,
     name,
     form,
     required,
@@ -205,12 +206,6 @@
   const { base, dropdown, item: dropdownItem, close, select, placeholder: placeholderSpan, svg } = $derived(multiSelect({ disabled, grouped: !!group }));
 </script>
 
-<select {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
-  {#each items as item (item.value)}
-    <option value={item.value} disabled={item.disabled}>{item.name}</option>
-  {/each}
-</select>
-
 <div
   bind:this={multiSelectContainer}
   {...restProps}
@@ -221,6 +216,12 @@
   role="listbox"
   class={base({ size, class: clsx(theme?.base, className) })}
 >
+  <select {id} {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
+    {#each items as item (item.value)}
+      <option value={item.value} disabled={item.disabled}>{item.name}</option>
+    {/each}
+  </select>
+
   {#if !selectItems.length}
     <span class={placeholderSpan({ class: clsx(classes?.placeholder) })}>{placeholder}</span>
   {/if}


### PR DESCRIPTION
<!--
Thanks for contributing to Flowbite-Svelte! 🤗

Please keep pull requests focused and scoped to a single change (feature, fix, docs, refactor, etc.).
If you have multiple unrelated changes, open multiple PRs instead of one large one.
-->

## 📑 Description

Currently the MultiSelect dropdown does not show when it is inside of a label. Or rather, it gets shown and immediately hidden again. Calling `preventDefault` on the onclick event fixes this.

---

## 🔍 PR Type

<!-- Select the type of change this PR introduces. -->

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor / Code cleanup
- [ ] Build / Tooling
- [ ] Other (please describe)

---

## 🚦 PR Status

- [ ] Draft (work in progress, not ready for review)
- [x] Ready for review ✅

---

## ✅ Checklist

<!-- Please confirm the following before requesting a review. -->

- [x] My code follows the existing code style
- [ ] I have run `pnpm lint && pnpm check && pnpm test:e2e` and all tests pass
- [ ] CoderabbitAI review has been completed and **actionable suggestions were reviewed**
- [x] I have updated documentation if my changes require it
- [x] My PR is based on the latest `main` branch (not the published npm version)
- [x] I have checked accessibility where applicable (ARIA, keyboard nav, etc.)
- [x] I have reviewed the rendered component in the browser

---

## ⚠️ Breaking Changes (optional)

I don't think anything breaks. If anything, then that the MultiSelect `id` prop is added to the `select` and not the wrapping `div` anymore.

---

## ℹ️ Additional Information

I have tested a few things.

```svelte
<!-- 1. MultiSelect alone -->
<MultiSelect {...props} />

<!-- 2. MultiSelect inside of label -->
<Label>
  My Label
  <MultiSelect {...props} />
</Label>

<!-- 3. MultiSelect with external label -->
<Label for="my-multiselect">My Label</Label>
<MultiSelect id="my-multiselect" {...props} />
```

Cases 1 and 3 work with the current version of flowbite-svelte, but case 3 does not open the dropdown when the label is clicked.

With only `event.preventDefault()` all cases work, case 2 and 3 behave the same: the dropdown does not get shown when the label itself is clicked.
```diff
  const toggleDropdown = (event: MouseEvent) => {
    if (disabled) return;
    // Prevent immediate closing if the click originated from within the component itself
    // This is useful if the click triggers a re-render and focus is lost momentarily.
    if (multiSelectContainer && multiSelectContainer.contains(event.target as Node)) {
      show = !show;
+      event.preventDefault();
    } else {
      show = false; // Close if clicked outside
    }
  };
```

When also moving the hidden select element inside on the MultiSelect div wrapper element, case 2 works and it opens the dropdown when the label is clicked. Case 3 however stays unaffected.
```diff
-<select {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
-  {#each items as item (item.value)}
-    <option value={item.value} disabled={item.disabled}>{item.name}</option>
- {/each}
-</select>
-
<div
  bind:this={multiSelectContainer}
  {...restProps}
  onclick={toggleDropdown}
  onblur={handleBlur}
  onkeydown={handleKeyDown}
  tabindex="0"
  role="listbox"
  class={base({ size, class: clsx(theme?.base, className) })}
>
+  <select {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
+    {#each items as item (item.value)}
+      <option value={item.value} disabled={item.disabled}>{item.name}</option>
+    {/each}
+  </select>
+
  {#if !selectItems.length}
    <span class={placeholderSpan({ class: clsx(classes?.placeholder) })}>{placeholder}</span>
  {/if}
```

If we additionally add the `restProps.id` property to the hidden select, so that clicking the label is a click on the select again, then all cases work and in both case 2 and 3 the dropdown shows when clicking the label.
```diff
<script>
[...]
  let {
    children,
    items = [],
    value = $bindable(),
[...]
    // Extract select-specific props
+    id,
    name,
    form,
    required,
    autocomplete,
    ...restProps
  }: MultiSelectProps<T> = $props();
[...]
</script>

[...]

<div
  bind:this={multiSelectContainer}
  {...restProps}
  onclick={toggleDropdown}
  onblur={handleBlur}
  onkeydown={handleKeyDown}
  tabindex="0"
  role="listbox"
  class={base({ size, class: clsx(theme?.base, className) })}
>
-  <select {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
+  <select {id} {name} {form} {required} {autocomplete} {value} hidden multiple {onchange}>
    {#each items as item (item.value)}
      <option value={item.value} disabled={item.disabled}>{item.name}</option>
    {/each}
  </select>

  {#if !selectItems.length}
    <span class={placeholderSpan({ class: clsx(classes?.placeholder) })}>{placeholder}</span>
  {/if}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MultiSelect component now accepts an `id` prop.

* **Bug Fixes**
  * Fixed dropdown toggle behavior that could trigger unintended actions.
  * Improved internal structure of the select element for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->